### PR TITLE
Add github-issues-prs skill to proxy-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ steg i integrations.
 ## Sikkerhetsmodell
 
 - Bare `integrations/` har Slack-/GitHub-tokens; agentene ser kun jsonl-filene
-  og sitt eget `workspace/`.
+  og sitt eget `workspace/`. Ett bevisst unntak: proxy-agent kan få et snevert
+  `GH_TOKEN` (kun issues/PR-er, ingen kode-tilgang) for github-skillen — se
+  [`agents/proxy-agent/README.md`](agents/proxy-agent/README.md).
 - Agent-containerne kjører som ikke-root med `cap_drop: ALL` og
   `no-new-privileges`, og trenger bare nettverk mot LLM-endepunktet.
 - Ingen inngående webhooks: integrations bruker polling (GitHub) og websocket

--- a/agents/proxy-agent/.env.example
+++ b/agents/proxy-agent/.env.example
@@ -14,5 +14,13 @@ LLM_API_KEY=none
 # Valgfritt: overstyr modellvalget (sendes som pi --model)
 PI_MODEL=
 
+# --- GitHub-skill (issues/PR-er) ---
+# Token for agentens GitHub-interaksjon (github-issues-prs-skillen).
+# Dette er et BEVISST unntak fra "ingen tokens hos agenten" — hold det snevert:
+# en fine-grained PAT med Read+Write på KUN "Issues" og "Pull requests"
+# (+ Metadata: read) på de aktuelle repoene. Ikke gi Contents-tilgang;
+# koding gjøres av en annen agent. Tomt = skillen er inaktiv.
+GH_TOKEN=
+
 # Hvor ofte (sekunder) watch-modus sjekker triggers/inbox.jsonl
 POLL_INTERVAL=5

--- a/agents/proxy-agent/.gitattributes
+++ b/agents/proxy-agent/.gitattributes
@@ -1,3 +1,5 @@
 # Shell-skript må ha LF for å kjøre i containeren
 *.sh text eol=lf
 Dockerfile text eol=lf
+# Skills kopieres inn i imaget; LF så frontmatter parses likt overalt
+docker/skills/** text eol=lf

--- a/agents/proxy-agent/README.md
+++ b/agents/proxy-agent/README.md
@@ -100,6 +100,22 @@ faller da tilbake til å poste hele loggen.
 Mottakeren bruker `intent` til å avgjøre responsen: `action`/`feedback` postes
 som svar/kommentar, mens `ack` bare kvitteres med en emoji-reaksjon.
 
+## Skills
+
+Agenten har [Pi-skills](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/skills.md)
+bakt inn i imaget under `docker/skills/` (lastes med `--skill` fra
+entrypointet — de kan ikke ligge i `~/.pi`, siden pi-home-volumet skygger
+image-innhold). Ny skill = ny katalog med en `SKILL.md` + rebuild.
+
+### github-issues-prs
+
+Lar agenten opprette, kommentere og administrere GitHub-issues og PR-er via
+`gh` CLI. Krever `GH_TOKEN` i `.env`: en **fine-grained PAT med kun Issues +
+Pull requests (Read/Write) og Metadata (Read)** på de aktuelle repoene. Dette
+er et bevisst, snevert unntak fra prinsippet om at agenten ikke har tokens —
+tokenet gir ikke tilgang til kode, og skillen instruerer agenten om at
+kodearbeid hører til en annen agent i pipelinen.
+
 ## Isolasjon
 
 - Agenten kjører som ikke-root (`node`-brukeren) i containeren

--- a/agents/proxy-agent/docker/Dockerfile
+++ b/agents/proxy-agent/docker/Dockerfile
@@ -6,6 +6,20 @@ RUN apt-get update \
 
 RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 
+# GitHub CLI — brukes av github-issues-prs-skillen (auth via GH_TOKEN)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      >/etc/apt/sources.list.d/github-cli.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Skills bakes inn utenfor /home/node/.pi — pi-home-volumet ville ellers
+# skygget dem ved image-oppdateringer. Entrypointet laster dem med --skill.
+COPY skills /opt/pi-skills
+RUN find /opt/pi-skills -type f -exec sed -i 's/\r$//' {} +
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 # CRLF-stripp i tilfelle imaget bygges fra en Windows-checkout
 RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh \

--- a/agents/proxy-agent/docker/entrypoint.sh
+++ b/agents/proxy-agent/docker/entrypoint.sh
@@ -35,6 +35,15 @@ if [[ -n "$PI_MODEL" ]]; then
   pi_args+=(--model "$PI_MODEL")
 fi
 
+# Skills bakt inn i imaget (se Dockerfile). Lastes eksplisitt med --skill
+# siden ~/.pi ligger på et volum som ville skygget image-innhold.
+SKILLS_DIR="${SKILLS_DIR:-/opt/pi-skills}"
+if [[ -d "$SKILLS_DIR" ]]; then
+  for skill_dir in "$SKILLS_DIR"/*/; do
+    [[ -f "$skill_dir/SKILL.md" ]] && pi_args+=(--skill "${skill_dir%/}")
+  done
+fi
+
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
 }

--- a/agents/proxy-agent/docker/skills/github-issues-prs/SKILL.md
+++ b/agents/proxy-agent/docker/skills/github-issues-prs/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: github-issues-prs
+description: Opprett, kommenter og administrer GitHub-issues og pull requests med gh CLI. Bruk denne når henvendelsen gjelder å lage et issue, svare/kommentere på et issue eller en PR, endre labels/tilordning, lukke/gjenåpne, eller hente status og innhold fra issues/PR-er.
+---
+
+# GitHub: issues og pull requests
+
+Du har `gh` (GitHub CLI) tilgjengelig, ferdig autentisert via miljøvariabelen
+`GH_TOKEN`. Tokenet er med vilje snevert: det gir kun tilgang til **issues og
+pull requests** (pluss metadata) på utvalgte repoer — ikke kode.
+
+## Grunnregler
+
+- Oppgi alltid repo eksplisitt med `--repo <owner>/<repo>` — `/workspace` er
+  ikke nødvendigvis en git-checkout av repoet det gjelder.
+- Repo og issue-/PR-nummer står som regel i trigger-eventets `payload`
+  (f.eks. `payload.repo`, `payload.issue`). Bruk det; ikke gjett.
+- Skriv kommentarer/issue-tekst på norsk med mindre tråden går på engelsk.
+- Feiler `gh` med auth-feil, er `GH_TOKEN` ikke satt eller mangler tilgang til
+  repoet — si det i svaret ditt i stedet for å prøve å omgå det.
+
+## Vanlige operasjoner
+
+```bash
+# Issues
+gh issue list    --repo OWNER/REPO --state open
+gh issue view    42 --repo OWNER/REPO --comments
+gh issue create  --repo OWNER/REPO --title "..." --body "..."
+gh issue comment 42 --repo OWNER/REPO --body "..."
+gh issue edit    42 --repo OWNER/REPO --add-label bug --add-assignee USER
+gh issue close   42 --repo OWNER/REPO --comment "..."
+
+# Pull requests
+gh pr list    --repo OWNER/REPO
+gh pr view    17 --repo OWNER/REPO --comments
+gh pr diff    17 --repo OWNER/REPO           # les endringene (read-only)
+gh pr comment 17 --repo OWNER/REPO --body "..."
+gh pr review  17 --repo OWNER/REPO --comment --body "..."
+
+# Alt annet (reaksjoner, review-tråder, søk): gh api
+gh api repos/OWNER/REPO/issues/42/reactions -f content=+1
+```
+
+Bruk `--body-file` med en midlertidig fil for lengre tekster, så unngår du
+quoting-trøbbel.
+
+## Avgrensning: ingen koding
+
+Selve kodearbeidet (branches, commits, push, merge) er en **annen agents**
+ansvar. Du skal derfor aldri:
+
+- merge, lukke eller gjenåpne PR-er uten at det er eksplisitt bedt om
+- godkjenne PR-er (`gh pr review --approve`)
+- forsøke å endre kode eller pushe (tokenet tillater det uansett ikke)
+
+Blir du bedt om å fikse kode, kommenter heller på issuet/PR-en at oppgaven er
+notert og sendes videre til kodeagenten, og gjenspeil det i `reply`-feltet.


### PR DESCRIPTION
## Hva

Gir proxy-agenten mulighet til å opprette, kommentere og administrere GitHub-issues og pull requests via `gh` CLI — som en Pi-skill.

## Hvordan

- **`gh` CLI** installeres i proxy-agent-imaget; auth skjer automatisk via `GH_TOKEN` fra `.env`
- **Pi-skills** bakes inn i imaget under `/opt/pi-skills` og lastes med `--skill` fra entrypointet (de kan ikke ligge i `~/.pi` — pi-home-volumet skygger image-innhold). Nye skills = ny katalog med `SKILL.md` + rebuild
- **`docker/skills/github-issues-prs/SKILL.md`** instruerer agenten: alltid eksplisitt `--repo` fra eventets payload, norsk i tråder, og aldri merge/approve/kode — kodearbeid er reservert for en fremtidig kodeagent i pipelinen

## Sikkerhet

`GH_TOKEN` er et bevisst, snevert unntak fra prinsippet om at agentene ikke har tokens: en fine-grained PAT med kun **Issues + Pull requests (Read/Write) og Metadata (Read)** — ingen Contents-tilgang. Dokumentert i `.env.example`, komponent-README og rot-README.

## Testet

- Imaget bygger; `gh 2.96.0` svarer i containeren
- Oneshot-kjøring mot lokalt LLM-endepunkt viser at agenten ser og beskriver skillen
- Verifisert i praksis via Slack → agent-svar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub issue and pull request management capabilities through a dedicated skill.
  * Supports creating, viewing, commenting on, editing, and managing issues and pull requests.
  * GitHub access can be enabled with a narrowly scoped token limited to issues and pull requests.
  * Skills are automatically detected and loaded when available.

* **Documentation**
  * Added setup guidance, usage instructions, permissions details, and operational boundaries for GitHub integration.
  * Documented the security exception and token configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->