### PR TITLE
Fiks: GitHub-polleren dedupérer på hendelse, ikke notifikasjonstråd

### DIFF
--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,11 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-21** — Fiks i integrations: GitHub-polleren deduperte på
+  notifikasjonstrådens ID (stabil per issue), slik at all senere interaksjon
+  med et allerede håndtert issue ble droppet stille i samme sesjon. Dedupérer
+  nå på hendelses-ID-en fra `eventIdFor` (per kommentar / per oppdatering).
+
 - **2026-07-21** — M3 i [plans/agent-delegering.md](plans/agent-delegering.md):
   ny skill `solution-proposal` i proxy-agenten — henvendelser som krever
   kodeendringer analyseres (read-only `/repos`), struktureres som

--- a/integrations/src/github/poller.ts
+++ b/integrations/src/github/poller.ts
@@ -89,7 +89,18 @@ export class GithubPoller {
     // the thread id would silently drop every later interaction with an issue
     // that was already handled once in this session.
     const key = eventIdFor(n);
-    if (this.handled.has(key)) return;
+    if (this.handled.has(key)) {
+      // Already acted on this event — the thread can only reappear with the
+      // same key when markThreadRead below failed transiently. Retry just the
+      // read bookkeeping so the notification stops resurfacing every poll,
+      // without redoing the actions themselves.
+      try {
+        await this.client.markThreadRead(n.id);
+      } catch (err) {
+        log.warn(`Could not mark handled thread read on ${n.repository.full_name}; retrying next poll.`, err);
+      }
+      return;
+    }
 
     const where = `${n.repository.full_name} "${n.subject.title}"`;
 

--- a/integrations/src/github/poller.ts
+++ b/integrations/src/github/poller.ts
@@ -84,7 +84,12 @@ export class GithubPoller {
   }
 
   private async handle(n: GithubNotification): Promise<void> {
-    if (this.handled.has(n.id)) return;
+    // Dedupe on the event id (per comment / per update) — NOT the notification
+    // id, which GitHub keeps stable for the whole thread (issue/PR). Keying on
+    // the thread id would silently drop every later interaction with an issue
+    // that was already handled once in this session.
+    const key = eventIdFor(n);
+    if (this.handled.has(key)) return;
 
     const where = `${n.repository.full_name} "${n.subject.title}"`;
 
@@ -106,7 +111,7 @@ export class GithubPoller {
       // assignees directly makes this independent of the notification reason.
       await this.unassignSelfIfAssigned(n, where);
 
-      this.handled.add(n.id);
+      this.handled.add(key);
       await this.client.markThreadRead(n.id);
     } catch (err) {
       log.error(`Failed to handle notification (reason=${n.reason}) on ${where}.`, err);


### PR DESCRIPTION
## Hva

GitHub-polleren droppet stille all senere interaksjon med et issue den allerede hadde håndtert én gang i samme sesjon.

## Hvorfor

`handled`-settet i `poller.ts` brukte notifikasjons-ID-en som nøkkel — men i GitHubs notifications-API er den ID-en **stabil per tråd** (issue/PR), ikke per hendelse. Observert i praksis på #41: en assign-hendelse ble håndtert kl. 15:52:38, og @-mention-kommentaren 19 sekunder senere (samme tråd → samme ID) ble avvist av `handled.has(...)` i hver eneste poll-runde etterpå.

## Hvordan

Dedupe-nøkkelen er nå `eventIdFor(n)` — som allerede er event-identiteten nedstrøms i køen: kommentar-ID når det finnes en utløsende kommentar, ellers trådens `updated_at`. Ny aktivitet på et kjent issue gir dermed ny nøkkel og håndteres, mens duplikater innen samme poll-runde fortsatt dedupéres.

- `integrations/src/github/poller.ts`: nøkkel byttet fra `n.id` til `eventIdFor(n)` (allerede importert)
- `doc/log.md`: loggført

## Verifisering

- `npm run typecheck` grønn
- Merk: `handled`-settet er i minnet, så den fortsatt uleste mention-en på #41 plukkes opp av en container-restart uavhengig av denne fiksen — fiksen hindrer at det skjer igjen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented GitHub notifications from being processed more than once during the same session.
  * Ensured repeated interactions on an already-handled issue are ignored quietly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->