### PR TITLE
Prosess-hygiene i delegeringsflyten: proxy-agenten eier issuen ende-til-ende

### DIFF
--- a/agents/local-cc-coding-agent/CLAUDE.md
+++ b/agents/local-cc-coding-agent/CLAUDE.md
@@ -45,6 +45,11 @@ Når du blir bedt om å lytte på / sjekke innboksen:
   push til `main`/`v2.0` direkte, aldri force-push, aldri `--no-verify`.
 - Lever endringer som PR (`gh pr create`) og pek på PR-en i `reply` —
   mennesket er review-gaten.
+- Peker oppgaven på et issue: PR-body-en skal **alltid** inneholde
+  `Closes #<nr>`, slik at merge lukker issuet og GitHub linker issue ↔ PR.
+- Du administrerer **aldri** issues (ingen self-assign, labels eller
+  lukking) — det eier proxy-agenten. Din leveranse er branch + PR +
+  resultatlinje.
 - Ikke skriv filer i denne katalogen utenom `triggers/` — agent-katalogen
   skal holdes ren.
 

--- a/agents/proxy-agent/docker/skills/solution-proposal/SKILL.md
+++ b/agents/proxy-agent/docker/skills/solution-proposal/SKILL.md
@@ -46,6 +46,13 @@ denne strukturen:
 
 Tittel: kort og imperativ (f.eks. «Legg til retry i webhook-mottakeren»).
 
+Tildel deretter issuet til deg selv — du (bot-kontoen) eier issuet
+ende-til-ende, fra opprettelse til det lukkes av kodeagentens PR:
+
+```bash
+gh issue edit <nr> --repo <owner>/<repo> --add-assignee @me
+```
+
 ## 3. Deleger
 
 Avslutt med `===AGENT-RESULT===`-blokken med `intent: "delegate"`:
@@ -62,6 +69,10 @@ prompten må stå på egne ben:
 - Gjenta kjernen: hva som skal gjøres og i hvilket repo.
 - Leveransekrav: egen branch (`agent/<kort-navn>`), PR mot riktig
   base-branch, aldri push direkte til main.
+- Krev **eksplisitt** at PR-body-en inneholder `Closes #<nr>`, slik at
+  merge lukker issuet og GitHub linker issue ↔ PR. Kodeagenten skal ikke
+  administrere issuet utover det (ingen self-assign eller lukking) — det
+  eier du.
 
 ## Sikkerhet
 

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,14 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-21** — Prosess-hygiene i delegeringsflyten (issue #41):
+  proxy-agenten eier issues ende-til-ende — solution-proposal-skillen
+  self-assigner opprettede issues og krever `Closes #<nr>` i kodeagentens
+  PR-body; kodeagentens instruks presiserer Closes-kravet og at den aldri
+  administrerer issues; GitHub-polleren unassigner seg ikke lenger —
+  assignment fra et menneske er en arbeidsordre som legger issuen i
+  agent-køen (samme håndtering som mention).
+
 - **2026-07-21** — Fiks i integrations: GitHub-polleren deduperte på
   notifikasjonstrådens ID (stabil per issue), slik at all senere interaksjon
   med et allerede håndtert issue ble droppet stille i samme sesjon. Dedupérer

--- a/integrations/.env.example
+++ b/integrations/.env.example
@@ -6,7 +6,7 @@
 # Set to "true" to enable polling GitHub notifications for the token's user.
 GITHUB_ENABLED=true
 
-# Token for issue/PR actions (unassign self, add reactions). A fine-grained PAT
+# Token for issue/PR actions (add reactions, comment). A fine-grained PAT
 # works here: Read+Write to "Issues" and "Pull requests" on the target repos.
 # A classic PAT with `repo` also works.
 GITHUB_TOKEN=

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -7,7 +7,9 @@ an inbound webhook endpoint, so it can run entirely from your laptop.
 ## What it does
 
 **GitHub** (polls the notifications API for the token's user):
-- When the bot is **assigned** to an issue or PR → it **unassigns itself**.
+- When the bot is **assigned** to an issue or PR → the assignment is a **work
+  order**: it stays in place (the bot account owns the issue end-to-end) and
+  the issue is handed to the agent queue, same as a mention.
 - When the bot is **@-mentioned** in a comment or body → it reacts with 🚀
   (`rocket`, configurable) on the triggering comment (or the issue/PR itself).
 
@@ -104,7 +106,7 @@ only sees assignments/mentions delivered to that account's notifications.
 The notifications API does **not** work with fine-grained PATs, so credentials
 are split into two roles:
 
-- **`GITHUB_TOKEN`** — issue/PR actions (unassign, react). A **fine-grained** PAT
+- **`GITHUB_TOKEN`** — issue/PR actions (react, comment). A **fine-grained** PAT
   with Read+Write on *Issues* and *Pull requests* works, as does a classic `repo`
   token.
 - **`GITHUB_TOKEN_CLASSIC_NOTIFICATIONS`** — the notifications API. Must be a

--- a/integrations/src/github/poller.ts
+++ b/integrations/src/github/poller.ts
@@ -112,15 +112,10 @@ export class GithubPoller {
     }
 
     try {
-      // React to @-mentions.
-      if (n.reason === "mention" || n.reason === "team_mention") {
-        await this.handleMention(n, where);
-      }
-      // Unassign self whenever currently assigned. A notification thread only
-      // carries one reason at a time, so an assignment can hide behind
-      // reason=mention when the same issue was also mentioned — checking the
-      // assignees directly makes this independent of the notification reason.
-      await this.unassignSelfIfAssigned(n, where);
+      // Mentions and assignments are both work orders: a human assigning the
+      // bot to an issue means "put the agent on this". The assignment stays
+      // in place — the bot account owns the issue until it is resolved.
+      await this.handleWorkOrder(n, where);
 
       this.handled.add(key);
       await this.client.markThreadRead(n.id);
@@ -129,29 +124,7 @@ export class GithubPoller {
     }
   }
 
-  private async unassignSelfIfAssigned(n: GithubNotification, where: string): Promise<void> {
-    if (!n.subject.url) return;
-    const issueNumber = issueNumberFrom(n.subject.url);
-    if (issueNumber === null) {
-      log.warn(`Could not resolve issue number from ${n.subject.url} on ${where}.`);
-      return;
-    }
-
-    const assignees = await this.client.listAssignees(n.subject.url);
-    if (!assignees.includes(this.login)) return; // Not assigned — nothing to do.
-
-    await this.client.removeAssignee(
-      n.repository.owner.login,
-      n.repository.name,
-      issueNumber,
-      this.login,
-    );
-    const others = assignees.filter((a) => a !== this.login);
-    const remaining = others.length ? ` (left ${others.length} other assignee(s) in place)` : "";
-    log.info(`Unassigned self from ${where} (#${issueNumber})${remaining}.`);
-  }
-
-  private async handleMention(n: GithubNotification, where: string): Promise<void> {
+  private async handleWorkOrder(n: GithubNotification, where: string): Promise<void> {
     // When we will post an answer back, react with a transient "working"
     // reaction that gets cleared once answered; otherwise leave a persistent
     // acknowledgement reaction.
@@ -162,15 +135,15 @@ export class GithubPoller {
     let reactionId: number | null = null;
     if (reactionsUrl) {
       reactionId = await this.client.addReaction(reactionsUrl, reactionName);
-      log.info(`Reacted :${reactionName}: to mention on ${where}.`);
+      log.info(`Reacted :${reactionName}: to ${n.reason} on ${where}.`);
     } else {
-      log.warn(`Mentioned on ${where} but could not resolve a reaction target.`);
+      log.warn(`Notified (${n.reason}) on ${where} but could not resolve a reaction target.`);
     }
 
-    // Hand the mention off to the agent (if the queue bridge is enabled). Pass
-    // the reaction target only when we intend to clear it after answering.
+    // Hand the work order off to the agent (if the queue bridge is enabled).
+    // Pass the reaction target only when we intend to clear it after answering.
     if (this.queue) {
-      await this.enqueueMention(
+      await this.enqueueWorkOrder(
         n,
         where,
         willClear ? reactionsUrl : null,
@@ -179,7 +152,7 @@ export class GithubPoller {
     }
   }
 
-  private async enqueueMention(
+  private async enqueueWorkOrder(
     n: GithubNotification,
     where: string,
     reactionsUrl: string | null,
@@ -188,7 +161,7 @@ export class GithubPoller {
     if (!n.subject.url) return;
     const issueNumber = issueNumberFrom(n.subject.url);
     if (issueNumber === null) {
-      log.warn(`Mentioned on ${where} but could not resolve issue number; not queued.`);
+      log.warn(`Notified (${n.reason}) on ${where} but could not resolve issue number; not queued.`);
       return;
     }
 


### PR DESCRIPTION
Closes #41

## Hva

Eierskapsmodell: **proxy-agenten (bot-kontoen) eier issues den oppretter eller får tildelt, ende-til-ende**; kodeagenten leverer branch + PR og driver ingen egen issue-administrasjon.

- **solution-proposal-skillen**: etter `gh issue create` tildeler agenten seg selv (`gh issue edit <nr> --add-assignee @me`), og delegerings-prompten krever eksplisitt `Closes #<nr>` i PR-body-en (og presiserer at kodeagenten ikke administrerer issuet).
- **Kodeagentens instruks** (`agents/local-cc-coding-agent/CLAUDE.md`): PR-body skal alltid inneholde `Closes #<nr>` når oppgaven peker på et issue; aldri self-assign, labels eller lukking.
- **integrations**: `unassignSelfIfAssigned` er fjernet fra GitHub-polleren. En assignment fra et menneske behandles nå som en arbeidsordre: tildelingen blir stående og issuen legges i agent-køen — samme håndtering som en mention (`handleMention`/`enqueueMention` er omdøpt til `handleWorkOrder`/`enqueueWorkOrder`). README og `.env.example` oppdatert tilsvarende.
- **doc/log.md**: ny loggpost.

## Verifisering

- `npm run typecheck` i integrations: grønn.
- Akseptansekriteriene i #41 dekkes av punktene over; selve self-assign/Closes-atferden verifiseres i neste ende-til-ende-kjøring av delegeringsflyten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)