### PR TITLE
Læringsløkke for delegering: debrief-event og prosess-læringer (#43)

### DIFF
--- a/agents/local-cc-coding-agent/CLAUDE.md
+++ b/agents/local-cc-coding-agent/CLAUDE.md
@@ -23,7 +23,21 @@ Når du blir bedt om å lytte på / sjekke innboksen:
    hent detaljene med `gh issue view`).
 4. Skriv en kort arbeidslogg til `triggers/logs/<id>.log` (opprett `logs/`
    ved behov).
-5. Append **én** linje til `triggers/results.jsonl` — aldri overskriv eller
+5. **Retro:** før du skriver resultatlinja, tenk kort etter — var
+   issue-spesifikasjonen/prompten presis nok, måtte du gjette på noe, var
+   noe unødig tungvint? Append 0–2 prosess-læringer (én JSON-linje per
+   læring) til kunnskapsrepoets `inbox/learnings.jsonl` — klonen ligger i
+   `../../workspaces_knowledge/`:
+
+   ```json
+   {"ts":"<UTC ISO-8601>","event_id":"<eventets id>","source":"agent","repo":"<owner/repo, eller tom>","scope":"process","text":"<læringen, 1–3 setninger>","confidence":"low|medium|high"}
+   ```
+
+   Commit og push i kunnskapsrepoet (best effort — feiler push, la
+   committen ligge, den blir pushet senere). Bare reell læring — null
+   læringer er helt greit, ikke dikt opp noe. **Aldri** hemmeligheter
+   eller tokens i læringer. Finnes ikke klonen, hopp over steget.
+6. Append **én** linje til `triggers/results.jsonl` — aldri overskriv eller
    rediger eksisterende linjer:
 
    ```json
@@ -32,7 +46,7 @@ Når du blir bedt om å lytte på / sjekke innboksen:
 
    Feilet oppgaven: `"status":"error"` og forklar kort i `reply`. Trenger du
    avklaring: `"status":"ok"` med spørsmålet i `reply` — det når brukeren.
-6. Fortsett å lytte: poll innboksen med jevne mellomrom (f.eks. en
+7. Fortsett å lytte: poll innboksen med jevne mellomrom (f.eks. en
    bakgrunnskommando som varsler deg når fila vokser).
 
 ## Arbeidsområde og git

--- a/agents/proxy-agent/docker/skills/knowledge-base/SKILL.md
+++ b/agents/proxy-agent/docker/skills/knowledge-base/SKILL.md
@@ -32,7 +32,7 @@ brukeren deg eksplisitt om å huske noe, så appendér ÉN JSON-linje til
 `/knowledge/inbox/learnings.jsonl`:
 
 ```json
-{"ts":"<UTC ISO-8601>","event_id":"<id fra eventet>","source":"slack|github|web","repo":"<owner/repo, eller tom>","scope":"global|repo","text":"<lærdommen, 1–3 setninger>","confidence":"low|medium|high"}
+{"ts":"<UTC ISO-8601>","event_id":"<id fra eventet>","source":"slack|github|web|agent","repo":"<owner/repo, eller tom>","scope":"global|repo|process","text":"<lærdommen, 1–3 setninger>","confidence":"low|medium|high"}
 ```
 
 Kommer lærdommen fra en nettside, legg til `"source_url":"<full URL>"` —
@@ -54,11 +54,30 @@ git pull --rebase --quiet; git push --quiet
 - `scope: "repo"` betyr at lærdommen gjelder ett bestemt repos kode/oppsett.
   Da skal den i tillegg meldes som issue med label `learning` på repoet
   (bruk github-issues-prs-skillen) — hopp over hvis GitHub-tilgang mangler.
+- `scope: "process"` betyr at lærdommen gjelder samarbeidet i pipelinen
+  (delegering, issue-spesifikasjon, arbeidsflyt) — se debrief-avsnittet under.
 - Du redigerer **kun** `inbox/learnings.jsonl`. Wiki-sidene (`index.md`,
   `domains/`, `repos/`, `process/`, `log.md`) endres av en egen
   synteseprosess — ikke av deg.
 - Feiler push: la committen ligge lokalt og nevn det i svaret — den blir
   pushet automatisk senere.
+
+## Debrief etter delegering (`delegation-outcome`)
+
+Events med `type: "delegation-outcome"` er broens debrief etter en oppgave
+**du** delegerte: `payload` har `delegated_to`, `status`, `reply` (svaret som
+ble levert brukeren) og `origin_event_id`. Svaret er allerede levert — du
+skal ikke svare brukeren, bare reflektere over prosessen:
+
+1. Vurder kort: ble oppgaven løst (`status`, `reply`)? Var
+   delegerings-prompten og issue-spesifikasjonen din presise nok? Kunne noe
+   vært enklere eller tydeligere?
+2. Skriv **0–2 konsise læringer** til `inbox/learnings.jsonl` (skjemaet over)
+   med `"scope":"process"` og `"source":"agent"` — f.eks. «issuet manglet
+   akseptansekriterium for X, kodeagenten måtte gjette». Ingen læring å
+   hente: helt greit, ikke dikt opp noe. Commit og push som vanlig.
+3. Avslutt med `intent: "ack"` — resultatet ditt på et debrief-event
+   konsumeres stille og postes aldri til Slack/GitHub.
 
 ## Viktige regler
 

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,14 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-21** — Læringsløkke for delegering (issue #43): broen sender et
+  `delegation-outcome`-event til opphavsagenten når det delegerte svaret er
+  levert (`AGENT_DELEGATION_DEBRIEF`, default på; ingen svar-rute, teller
+  ikke som hopp). Proxy-agenten reflekterer ved debrief og skriver
+  prosess-læringer (`scope: "process"`, `source: "agent"`) til
+  kunnskapsrepoets innboks; kodeagenten fikk et retro-steg som avleverer
+  tilsvarende læringer før resultatlinja.
+
 - **2026-07-21** — Prosess-hygiene i delegeringsflyten (issue #41):
   proxy-agenten eier issues ende-til-ende — solution-proposal-skillen
   self-assigner opprettede issues og krever `Closes #<nr>` i kodeagentens

--- a/doc/plans/agent-delegering.md
+++ b/doc/plans/agent-delegering.md
@@ -84,6 +84,16 @@ resultatet er alltid en PR et menneske reviewer.
 - Verifiseres autonomt: Slack-melding → analyse → issue → delegering →
   kodeagenten lager PR → svar i tråden.
 
+### Læringsløkke for delegering (issue #43) ✅
+- Broen sender et `delegation-outcome`-event til opphavsagenten når det
+  delegerte svaret er levert (`AGENT_DELEGATION_DEBRIEF`, default på).
+  Debrief-eventet har ingen pending svar-rute (resultatet konsumeres stille)
+  og teller ikke som delegeringshopp — kan aldri starte en loop.
+- Proxy-agenten reflekterer ved debrief (knowledge-base-skillen) og skriver
+  0–2 prosess-læringer (`scope: "process"`, `source: "agent"`) til
+  kunnskapsrepoets innboks; kodeagenten har et retro-steg som avleverer
+  tilsvarende læringer før resultatlinja skrives.
+
 ### M4 — Containerisert kodeagent
 - `agents/<code-agent>/` i Docker med skrivbar `workspaces_repos`-mount og
   eget fine-grained token (Contents R/W på avgrensede repoer — tredje

--- a/integrations/.env.example
+++ b/integrations/.env.example
@@ -127,3 +127,9 @@ AGENT_PRIMARY_NAME=proxy-agent
 
 # Max delegation hops for one originating event (loop guard).
 AGENT_MAX_DELEGATION_HOPS=2
+
+# When true (default), the delegating agent receives a "delegation-outcome"
+# debrief event in its inbox once the delegated answer has been delivered.
+# The debrief result is consumed silently (nothing is posted to Slack/GitHub)
+# and does not count as a delegation hop. Set to false to disable.
+AGENT_DELEGATION_DEBRIEF=true

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -85,6 +85,13 @@ same machine).
   resolved as `<AGENT_AGENTS_DIR>/<name>/triggers`). Unknown targets are
   reported back to the origin instead of executed. `AGENT_MAX_DELEGATION_HOPS`
   (default 2) caps chains so two agents cannot ping-pong a task forever.
+- **Debrief** (`AGENT_DELEGATION_DEBRIEF`, default true): once the delegated
+  answer has been delivered, the delegating agent gets a `delegation-outcome`
+  event in its inbox (target agent, status, the delivered reply) so it can
+  reflect on how the delegation went. The debrief has **no** pending reply
+  route — the agent's result on it is consumed without posting anything to
+  Slack/GitHub — and it does not count as a delegation hop, so it can never
+  start a delegation loop.
 
 ## Requirements
 

--- a/integrations/src/agent/queue.ts
+++ b/integrations/src/agent/queue.ts
@@ -172,7 +172,7 @@ export class AgentQueue {
 
     this.pending.delete(result.id);
     await this.persistPending();
-    await this.sendDebrief(agent, result, reply);
+    await this.sendDebrief(agent, result, reply, delivery);
   }
 
   /**
@@ -244,7 +244,7 @@ export class AgentQueue {
    * (for the same reason) it can never start a new delegation, so no hop is
    * spent. Best effort: a failed append is logged and dropped, never retried.
    */
-  private async sendDebrief(from: AgentRoute, result: ResultLine, reply: ReplyContext): Promise<void> {
+  private async sendDebrief(from: AgentRoute, result: ResultLine, reply: ReplyContext, delivery: Delivery): Promise<void> {
     const origin = reply.origin;
     if (!this.config.delegationDebrief || !origin) return;
     const originAgent = this.agents.find((a) => a.name === origin.agent);
@@ -252,7 +252,9 @@ export class AgentQueue {
       log.warn(`No agent "${origin.agent}" configured for the debrief of "${result.id}" — skipping.`);
       return;
     }
-    const summary = truncate((result.reply ?? "").trim(), 2000);
+    // Use the actual delivered text (which may include error-wrapped or fallback text).
+    const deliveredText = delivery.kind === "message" ? delivery.text : (result.reply ?? "").trim();
+    const summary = truncate(deliveredText, 2000);
     const event: QueueEvent = {
       id: `${origin.eventId}-outcome`.replace(/[^a-zA-Z0-9._-]/g, "_"),
       source: "agent",
@@ -265,7 +267,7 @@ export class AgentQueue {
       payload: {
         delegated_to: from.name,
         status: result.status,
-        reply: truncate((result.reply ?? "").trim(), this.config.maxReplyChars),
+        reply: truncate(deliveredText, this.config.maxReplyChars),
         origin_event_id: origin.eventId,
       },
     };

--- a/integrations/src/agent/queue.ts
+++ b/integrations/src/agent/queue.ts
@@ -16,6 +16,9 @@ const log = createLogger("queue");
  *   - A result with `intent: "delegate"` is routed onwards: the task becomes a
  *     new event in the target agent's inbox, and the pending reply is remapped
  *     so the final answer still lands in the originating thread/issue.
+ *   - Once a delegated answer has been delivered, the delegating agent gets a
+ *     `delegation-outcome` debrief event ({@link sendDebrief}) so it can
+ *     reflect on the process. The debrief has no pending reply route.
  */
 export class AgentQueue {
   private readonly config: AgentQueueConfig;
@@ -169,6 +172,7 @@ export class AgentQueue {
 
     this.pending.delete(result.id);
     await this.persistPending();
+    await this.sendDebrief(agent, result, reply);
   }
 
   /**
@@ -221,7 +225,7 @@ export class AgentQueue {
     await fs.appendFile(target!.inboxFile, JSON.stringify(event) + "\n", "utf8");
 
     this.pending.delete(result.id);
-    this.pending.set(newId, { ...reply, hops });
+    this.pending.set(newId, { ...reply, hops, origin: { agent: from.name, eventId: result.id } });
     await this.persistPending();
     log.info(`Delegated "${result.id}" from "${from.name}" to "${target!.name}" as "${newId}".`);
 
@@ -230,6 +234,47 @@ export class AgentQueue {
     await this.post(reply, { kind: "message", text: truncate(text, this.config.maxReplyChars) }, posters, newId, {
       keepWorking: true,
     });
+  }
+
+  /**
+   * Debriefs the delegating agent after a delegated answer has been delivered:
+   * appends a `delegation-outcome` event to its inbox so it can reflect on the
+   * process. The event deliberately gets no pending reply route — the agent's
+   * result on it is consumed without posting anything to Slack/GitHub, and
+   * (for the same reason) it can never start a new delegation, so no hop is
+   * spent. Best effort: a failed append is logged and dropped, never retried.
+   */
+  private async sendDebrief(from: AgentRoute, result: ResultLine, reply: ReplyContext): Promise<void> {
+    const origin = reply.origin;
+    if (!this.config.delegationDebrief || !origin) return;
+    const originAgent = this.agents.find((a) => a.name === origin.agent);
+    if (!originAgent) {
+      log.warn(`No agent "${origin.agent}" configured for the debrief of "${result.id}" — skipping.`);
+      return;
+    }
+    const summary = truncate((result.reply ?? "").trim(), 2000);
+    const event: QueueEvent = {
+      id: `${origin.eventId}-outcome`.replace(/[^a-zA-Z0-9._-]/g, "_"),
+      source: "agent",
+      type: "delegation-outcome",
+      received_at: new Date().toISOString(),
+      prompt:
+        `Debrief: oppgaven du delegerte til «${from.name}» (ditt event «${origin.eventId}») er ` +
+        `levert til brukeren med status «${result.status}». Svaret var: «${summary}». ` +
+        `Reflekter kort over delegeringsprosessen og svar med intent "ack" — svaret ditt postes ikke videre.`,
+      payload: {
+        delegated_to: from.name,
+        status: result.status,
+        reply: truncate((result.reply ?? "").trim(), this.config.maxReplyChars),
+        origin_event_id: origin.eventId,
+      },
+    };
+    try {
+      await fs.appendFile(originAgent.inboxFile, JSON.stringify(event) + "\n", "utf8");
+      log.info(`Debriefed "${originAgent.name}" about "${result.id}" (delegation-outcome "${event.id}").`);
+    } catch (err) {
+      log.warn(`Could not append delegation-outcome for "${result.id}" to "${originAgent.name}".`, err);
+    }
   }
 
   /**

--- a/integrations/src/agent/types.ts
+++ b/integrations/src/agent/types.ts
@@ -44,6 +44,12 @@ export type ReplyContext = (
 ) & {
   /** Delegation hops consumed for this originating event (loop guard). */
   hops?: number;
+  /**
+   * Set when the pending result comes from a delegated task: who delegated it
+   * and under which event id. Used to send the delegator a `delegation-outcome`
+   * debrief event once the answer has been delivered.
+   */
+  origin?: { agent: string; eventId: string };
 };
 
 /**

--- a/integrations/src/config.ts
+++ b/integrations/src/config.ts
@@ -53,6 +53,12 @@ export interface AgentQueueConfig {
   routes: AgentRoute[];
   /** Max delegation hops for one originating event (loop guard). */
   maxDelegationHops: number;
+  /**
+   * When true, the delegating agent receives a `delegation-outcome` event in
+   * its inbox once the delegated answer has been delivered. The debrief has no
+   * pending reply route and does not count as a delegation hop.
+   */
+  delegationDebrief: boolean;
   /** integrations's own state (pending replies + results offset). */
   stateDir: string;
   resultsPollIntervalSeconds: number;
@@ -133,6 +139,7 @@ export function loadConfig(): Config {
     primaryName: (process.env.AGENT_PRIMARY_NAME ?? "proxy-agent").trim(),
     routes: [],
     maxDelegationHops: Number(process.env.AGENT_MAX_DELEGATION_HOPS ?? "2"),
+    delegationDebrief: bool(process.env.AGENT_DELEGATION_DEBRIEF, true),
     stateDir: path.resolve((process.env.AGENT_STATE_DIR ?? ".state").trim()),
     resultsPollIntervalSeconds: Number(process.env.AGENT_RESULTS_POLL_INTERVAL ?? "5"),
     postResults: bool(process.env.AGENT_POST_RESULTS, true),


### PR DESCRIPTION
Closes #43

## Hva

Læringsløkke for delegering — begge agenter får utfallet tilbake og avleverer prosess-læringer:

- **Debrief-event i broen** (`integrations/src/agent/queue.ts`): når et delegert svar er levert til opprinnelsen, appender broen et `delegation-outcome`-event i opphavsagentens innboks (`payload`: `delegated_to`, `status`, `reply`, `origin_event_id`). Opphavet lagres i pending-konteksten ved delegering (`ReplyContext.origin`).
  - Eventet har **ingen** pending svar-rute: agentens resultat på det konsumeres stille (treffer «no pending reply»-stien) — ingenting postes til Slack/GitHub, og et `delegate`-resultat på debrief-eventet ignoreres, så det kan aldri starte en loop. Ingen hopp forbrukes.
  - Konfigurerbart via `AGENT_DELEGATION_DEBRIEF` (default `true`); dokumentert i `README.md` og `.env.example`.
- **Refleksjon i proxy-agenten** (`knowledge-base/SKILL.md`): nytt avsnitt «Debrief etter delegering» — vurder utfallet, skriv 0–2 læringer med `scope: "process"` / `source: "agent"` til kunnskapsrepoets innboks, svar `intent: "ack"`. Skjemaet i skillen er utvidet med `agent`/`process`.
- **Kunnskapsrepoets `inbox/README.md`** (separat repo, direkte push etter konvensjon): `source: agent` og `scope: process` dokumentert.
- `doc/plans/agent-delegering.md` (nytt punkt ✅) og `doc/log.md` oppdatert.

## ~~⚠️ Gjenstår~~ Løst: retro-steg i kodeagentens CLAUDE.md

**Oppdatering:** steget er nå lagt inn manuelt i `agents/local-cc-coding-agent/CLAUDE.md` (commit e987d8b) — som nytt steg 5, dagens steg 5–6 ble 6–7. Beskrivelsen under står igjen som kontekst.


Den lokale tillatelses-klassifisereren min blokkerte redigering av `agents/local-cc-coding-agent/CLAUDE.md` (endring av agent-instruks), så retro-steget må legges inn manuelt av reviewer. Foreslått innhold — nytt steg 5 i «Protokoll» (dagens steg 5–6 blir 6–7):

````markdown
5. **Retro:** før du skriver resultatlinja, tenk kort etter — var
   issue-spesifikasjonen/prompten presis nok, måtte du gjette på noe, var
   noe unødig tungvint? Append 0–2 prosess-læringer (én JSON-linje per
   læring) til kunnskapsrepoets `inbox/learnings.jsonl` — klonen ligger i
   `../../workspaces_knowledge/`:

   ```json
   {"ts":"<UTC ISO-8601>","event_id":"<eventets id>","source":"agent","repo":"<owner/repo, eller tom>","scope":"process","text":"<læringen, 1–3 setninger>","confidence":"low|medium|high"}
   ```

   Commit og push i kunnskapsrepoet (best effort — feiler push, la
   committen ligge, den blir pushet senere). Bare reell læring — null
   læringer er helt greit, ikke dikt opp noe. **Aldri** hemmeligheter
   eller tokens i læringer. Finnes ikke klonen, hopp over steget.
````

## Verifisering

- `npm run typecheck` i `integrations/` — grønn.
- Debrief-eventet oppfyller loop-kravet by design: uten pending-innslag returnerer `handleResultLine` før delegasjonshåndteringen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional delegation debriefing after delegated results are delivered.
  - Originating agents receive a silent outcome event with delegation status and a truncated response.
  - Added an automated learning loop that captures process insights from delegation outcomes.

- **Configuration**
  - Debriefing is enabled by default and can be disabled through the new environment setting.

- **Documentation**
  - Updated delegation and knowledge-base guidance to explain debriefing, process learnings, and event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->