### PR TITLE
Slack: working-reaction fjernes alltid ved levering, med full logging (#46)

### DIFF
--- a/integrations/src/slack/connector.ts
+++ b/integrations/src/slack/connector.ts
@@ -53,37 +53,66 @@ export class SlackConnector {
 
   /**
    * Delivers a result: either a threaded reply, or a silent ack that just adds
-   * the acknowledgement reaction to the original message. Either way the
-   * "working" reaction is cleared afterwards. Used by the result watcher.
+   * the acknowledgement reaction to the original message. The "working"
+   * reaction is **always** cleared afterwards — also when posting failed: a
+   * lingering :thinking_face: signals "still working" and is worse than a
+   * missing ack reaction. Used by the result watcher.
    */
   async deliver(reply: Extract<ReplyContext, { kind: "slack" }>, delivery: Delivery): Promise<void> {
-    if (delivery.kind === "message") {
-      await this.web.chat.postMessage({
-        channel: reply.channel,
-        thread_ts: reply.threadTs,
-        text: delivery.text,
-      });
-    } else if (reply.messageTs) {
-      // ack: acknowledge with a reaction on the original message.
-      await this.addReaction(reply.channel, reply.messageTs, this.config.ackReaction);
+    try {
+      if (delivery.kind === "message") {
+        await this.web.chat.postMessage({
+          channel: reply.channel,
+          thread_ts: reply.threadTs,
+          text: delivery.text,
+        });
+      } else if (reply.messageTs) {
+        // ack: acknowledge with a reaction on the original message. Best
+        // effort — a failed ack reaction must not block the cleanup below.
+        try {
+          await this.addReaction(reply.channel, reply.messageTs, this.config.ackReaction);
+        } catch (err) {
+          const code = (err as { data?: { error?: string } })?.data?.error;
+          log.warn(
+            `Could not add the ack reaction :${this.config.ackReaction}: in ${reply.channel} @ ${reply.messageTs} (${code ?? "unknown error"}).`,
+            err,
+          );
+        }
+      }
+    } finally {
+      await this.clearWorkingReaction(reply);
     }
-    await this.clearWorkingReaction(reply);
   }
 
-  /** Removes the transient "working" reaction from a message, if one was set. */
+  /**
+   * Removes the transient "working" reaction from a message, if one was set.
+   * Logs every attempt and outcome — a reaction that silently stays behind
+   * looks like the bot is still thinking (see issue #46). Never throws.
+   */
   private async clearWorkingReaction(reply: Extract<ReplyContext, { kind: "slack" }>): Promise<void> {
-    if (!reply.workingReaction || !reply.messageTs) return;
+    if (!reply.workingReaction || !reply.messageTs) {
+      log.debug(`No working reaction to clear in ${reply.channel} (workingReaction/messageTs not set on the reply context).`);
+      return;
+    }
     try {
       await this.web.reactions.remove({
         channel: reply.channel,
         timestamp: reply.messageTs,
         name: reply.workingReaction,
       });
+      log.info(`Cleared working reaction :${reply.workingReaction}: in ${reply.channel} @ ${reply.messageTs}.`);
     } catch (err) {
       const code = (err as { data?: { error?: string } })?.data?.error;
-      if (code !== "no_reaction") {
-        log.warn("Delivered the result but could not clear the working reaction.", err);
+      if (code === "no_reaction") {
+        // Nothing to remove (never added, or already removed) — worth a trace,
+        // not a warning.
+        log.info(`Working reaction :${reply.workingReaction}: in ${reply.channel} @ ${reply.messageTs} was already gone.`);
+        return;
       }
+      log.warn(
+        `Could not clear working reaction :${reply.workingReaction}: in ${reply.channel} @ ${reply.messageTs} (${code ?? "unknown error"}).`,
+        err,
+      );
     }
   }
 


### PR DESCRIPTION
Closes #46

## Analyse

Flyten `onMessage` → `enqueueMessage` → (resultat) → `deliver` → `clearWorkingReaction` er i utgangspunktet riktig koblet, men hadde tre stille feilmoduser som alle kunne etterlate `:thinking_face:`:

1. **Ack-stien kunne abortere oppryddingen**: i `deliver()` med `intent: "ack"` ble ack-reaksjonen lagt til *før* `clearWorkingReaction`. Feilet `reactions.add` (annet enn `already_reacted` kastes videre), ble `clearWorkingReaction` aldri nådd — og working-reaksjonen ble stående.
2. **Feilet posting hoppet over oppryddingen**: kastet `chat.postMessage`, ble `clearWorkingReaction` heller ikke nådd. Køen logger «will retry», men i praksis ble reaksjonen stående.
3. **`no_reaction` ble svelget stille og suksess ble aldri logget**: det fantes ingen måte å se i loggene om fjerning ble forsøkt, lyktes eller feilet — derfor har feilen vært usynlig (jf. driftsloggene, som ikke inneholder ett eneste spor av reaksjonsopprydding).

Merk: ved **delegering** beholder originalmeldingen working-reaksjonen med vilje etter interim-svaret («Delegert til …») — den fjernes først når det endelige svaret fra kodeagenten leveres. Det kan oppleves som «thinking_face blir stående» mens delegeringen pågår, men er designet adferd.

## Fiks (`integrations/src/slack/connector.ts`)

- `deliver()` rydder nå working-reaksjonen i en **`finally`-blokk** — den fjernes alltid, også når melding-posting eller ack-reaksjon feiler. En feilet ack-reaksjon er nedgradert til best effort med egen warning i stedet for å kaste.
- `clearWorkingReaction()` logger nå hvert utfall:
  - suksess → `INFO Cleared working reaction :x: in <channel> @ <ts>`
  - allerede borte (`no_reaction`) → `INFO … was already gone` (før: helt stille)
  - andre feil → `WARN` med kanal, ts, emoji-navn og Slack-feilkode + feilobjekt (akseptansekriterium 2)
  - manglende `workingReaction`/`messageTs` i reply-konteksten → `DEBUG`-spor

## Verifisering

- `npm run typecheck` — grønn.
- Test mot faktisk Slack (steg 4 i issuet) er ikke utført herfra — kodeagenten har ikke Slack-tokens; det verifiseres enklest ved å bygge/restarte integrations-containeren og sende en DM. Loggene viser nå eksplisitt hvert opprydningsforsøk, så en eventuell gjenværende feilmodus blir synlig umiddelbart.

## Observasjon utenfor scope

`queue.ts` har kommentarer om at en feilet levering «retries next cycle», men `drainResults` flytter offset forbi linjen uansett — en feilet posting blir i realiteten aldri forsøkt på nytt (svaret tapes stille og pending-innslaget blir liggende). Bør vurderes som egen issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
