### PR TITLE
Drift: dev-modus i forgrunnen + selvoppgradering med tilbakerulling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,51 @@ komponent kan fortsatt dras opp alene med `docker compose up` i sin katalog.
 Integrations kan også kjøres rett på hosten under utvikling (Node >= 23:
 `cd integrations && npm install && npm start`).
 
+### Utvikling i forgrunnen
+
+Default restart-policy er `unless-stopped`, slik at klyngen overlever omstart
+av Docker/maskinen. Til utvikling — logger rett i konsollen, Ctrl+C stopper
+alt, og ingenting starter igjen av seg selv — kjør:
+
+```powershell
+.\scripts\dev.ps1        # docker compose up --build uten restart-policy
+```
+
+Policyen styres av miljøvariabelen `RESTART_POLICY` i compose-filene
+(default `unless-stopped`; dev-skriptet setter `no`).
+
+## Drift og selvoppgradering
+
+Runtime-oppgradering «i fart» gjøres av
+[`scripts/self-update.ps1`](scripts/self-update.ps1), som kjører **på hosten,
+utenfor det den oppgraderer** — en container kan ikke trygt stoppe og
+gjenoppbygge seg selv, og agentene skal ikke ha Docker-tilgang (tilgang til
+docker-socketen tilsvarer root på hosten). Utløseren er merge til
+deploy-branchen: når agent-pipelinen selv har fått en PR merget, plukker
+skriptet det opp — menneskelig review forblir gaten.
+
+Skriptet følger A/B-prinsippet, men uten parallellkjøring (innboksene er
+single-consumer — to samtidige klynger dobbeltbehandler events):
+
+1. Kjørende images beholdes som `:rollback`-tag.
+2. `git pull --ff-only` (nekter ved skitten arbeidskopi), og nye images
+   **bygges mens den gamle klyngen fortsatt kjører** — byggefeil er den
+   vanligste «brick»-årsaken og gir her null nedetid.
+3. Bytte (`docker compose up -d`) og helsesjekk: containerne må kjøre stabilt
+   uten restarts, og komponentenes klar-meldinger må dukke opp i loggene.
+4. Ved feil rulles kode og images tilbake, og forrige versjon startes igjen.
+
+Restart er billig i denne arkitekturen: kø og state ligger i jsonl-filer og
+navngitte volumer, så events i innboksene overlever byttet.
+
+```powershell
+pwsh scripts\self-update.ps1                     # én sjekk/oppgradering nå
+pwsh scripts\self-update.ps1 -WatchSeconds 300   # følg deploy-branchen, poll hvert 5. min
+```
+
+For ubemannet drift kan skriptet registreres som gjentakende oppgave i Task
+Scheduler i stedet for `-WatchSeconds`.
+
 ## Legge til en ny agent
 
 Pipelinen utvides ved å legge nye agenter under `agents/<navn>/`. En agent er

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ single-consumer — to samtidige klynger dobbeltbehandler events):
 Restart er billig i denne arkitekturen: kø og state ligger i jsonl-filer og
 navngitte volumer, så events i innboksene overlever byttet.
 
+Skriptet er også drifts-inngangen: er koden allerede oppdatert men klyngen
+nede (første oppstart, etter reboot), startes den — én kommando dekker
+«start alt og hold det oppdatert».
+
 ```powershell
 pwsh scripts\self-update.ps1                     # én sjekk/oppgradering nå
 pwsh scripts\self-update.ps1 -WatchSeconds 300   # følg deploy-branchen, poll hvert 5. min

--- a/README.md
+++ b/README.md
@@ -100,6 +100,36 @@ pwsh scripts\self-update.ps1 -WatchSeconds 300   # følg deploy-branchen, poll h
 For ubemannet drift kan skriptet registreres som gjentakende oppgave i Task
 Scheduler i stedet for `-WatchSeconds`.
 
+### Dedikert deploy-klone
+
+Watcheren gjør `git pull` i klonen den kjører fra, og guardene (kun
+deploy-branchen, kun ren arbeidskopi) stopper den så snart du utvikler i
+samme klone. Kjør den derfor fra en egen klone som watcheren eier alene:
+
+```powershell
+git clone https://github.com/digdir/digdir-ai-agents.git C:\data\deploy\digdir-ai-agents
+cd C:\data\deploy\digdir-ai-agents
+git checkout v2.0
+Copy-Item <dev-klone>\integrations\.env integrations\           # .env er gitignorert
+Copy-Item <dev-klone>\agents\proxy-agent\.env agents\proxy-agent\
+pwsh scripts\self-update.ps1 -WatchSeconds 300
+```
+
+Merk:
+
+- **Kjør bare én klynge om gangen.** Compose-prosjektnavnet
+  (`digdir-ai-agents`) er felles, så `up` fra én klone tar over containerne
+  fra den andre (mountene peker da på den klonens kataloger). Det hindrer
+  dobbeltkonsumering av innboksene — men vær bevisst på hvilken klone som
+  «eier» klyngen.
+- **Kø-katalogene følger klonen.** Kjører integrations fra deploy-klonen,
+  havner delegerte oppgaver i *deploy-klonens*
+  `agents/local-cc-coding-agent/triggers/` — den interaktive
+  kodeagent-sesjonen må da startes derfra også.
+- Navngitte volumer (`integrations-state`, `pi-home`) deles via
+  prosjektnavnet, så pending replies og results-offsets overlever bytte av
+  klone.
+
 ## Legge til en ny agent
 
 Pipelinen utvides ved å legge nye agenter under `agents/<navn>/`. En agent er

--- a/agents/proxy-agent/docker-compose.yml
+++ b/agents/proxy-agent/docker-compose.yml
@@ -26,7 +26,9 @@ services:
       - ../../workspaces_repos:/repos:ro
       # Pi-innstillinger/sesjoner overlever container-restart
       - pi-home:/home/node/.pi
-    restart: unless-stopped
+    # Overstyrbar for utvikling i forgrunnen (scripts/dev.ps1 setter "no");
+    # default gjør at klyngen overlever omstart av Docker/maskinen.
+    restart: ${RESTART_POLICY:-unless-stopped}
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,13 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-22** — Drift: restart-policy gjort overstyrbar
+  (`RESTART_POLICY`, default `unless-stopped`) med `scripts/dev.ps1` for
+  utvikling i forgrunnen, og `scripts/self-update.ps1` for selvoppgradering
+  «i fart» fra hosten — bygger nye images før den kjørende klyngen røres,
+  helsesjekker etter bytte og ruller tilbake til `:rollback`-imagene ved
+  feil. Utløser: merge til deploy-branchen.
+
 - **2026-07-21** — Prosess-hygiene i delegeringsflyten (issue #41):
   proxy-agenten eier issues ende-til-ende — solution-proposal-skillen
   self-assigner opprettede issues og krever `Closes #<nr>` i kodeagentens

--- a/integrations/docker-compose.yml
+++ b/integrations/docker-compose.yml
@@ -20,7 +20,9 @@ services:
       - ../agents/local-cc-coding-agent/triggers:/agents/local-cc-coding-agent/triggers
       # Egen state (pending replies + results-offset) overlever restart
       - integrations-state:/state
-    restart: unless-stopped
+    # Overstyrbar for utvikling i forgrunnen (scripts/dev.ps1 setter "no");
+    # default gjør at klyngen overlever omstart av Docker/maskinen.
+    restart: ${RESTART_POLICY:-unless-stopped}
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,18 @@
+<#
+.SYNOPSIS
+  Kjører hele pipelinen i forgrunnen for utvikling: logger i konsollen,
+  Ctrl+C stopper alt, og ingenting starter igjen av seg selv.
+
+.DESCRIPTION
+  Setter RESTART_POLICY=no slik at compose-filenes
+  `restart: ${RESTART_POLICY:-unless-stopped}` ikke gir restart-policy på
+  dev-containerne. Alle ekstra argumenter sendes videre til
+  `docker compose up` (f.eks. `.\scripts\dev.ps1 --force-recreate`).
+#>
+$env:RESTART_POLICY = "no"
+Push-Location (Split-Path $PSScriptRoot -Parent)
+try {
+  docker compose up --build @args
+} finally {
+  Pop-Location
+}

--- a/scripts/self-update.ps1
+++ b/scripts/self-update.ps1
@@ -22,6 +22,9 @@
   Kø/state ligger i filer og navngitte volumer, så events i innboksene
   overlever byttet.
 
+  Skriptet er også drifts-inngangen: er koden allerede oppdatert men klyngen
+  nede (første oppstart, etter reboot), startes den. Én kommando å kjøre.
+
 .PARAMETER Branch
   Deploy-branchen som følges (default: v2.0). Arbeidskopien må stå på denne.
 
@@ -97,6 +100,17 @@ function Test-ClusterHealthy {
   return $false
 }
 
+function Start-ClusterIfDown {
+  $services = @(docker compose config --services | Where-Object { $_ })
+  $running = @(docker compose ps --status running --services | Where-Object { $_ })
+  $down = @($services | Where-Object { $running -notcontains $_ })
+  if ($down.Count -eq 0) { return }
+
+  Write-Step "Klyngen kjører ikke (mangler: $($down -join ', ')) — starter..."
+  docker compose up -d
+  if ($LASTEXITCODE -ne 0) { throw "Klarte ikke starte klyngen — se docker compose logs." }
+}
+
 function Restore-Previous {
   param([string]$OldSha, [bool]$WasClean, [string[]]$Images)
 
@@ -128,6 +142,9 @@ function Invoke-UpdatePass {
     $remoteSha = (git rev-parse "origin/$Branch").Trim()
     if ($localSha -eq $remoteSha) {
       Write-Step "Allerede på siste versjon ($($localSha.Substring(0, 7)))."
+      # Skriptet er også drifts-inngangen: sørg for at klyngen faktisk kjører
+      # (første oppstart, etter reboot med stoppede containere, o.l.).
+      Start-ClusterIfDown
       return
     }
 

--- a/scripts/self-update.ps1
+++ b/scripts/self-update.ps1
@@ -1,0 +1,188 @@
+<#
+.SYNOPSIS
+  Selvoppgradering av agent-runtimen «i fart»: hent siste kode på
+  deploy-branchen, bygg nye images FØR den kjørende klyngen røres, bytt over,
+  verifiser helse — og rull tilbake til forrige versjon ved feil.
+
+.DESCRIPTION
+  Kjører på HOSTEN, utenfor det som oppgraderes: en container kan ikke trygt
+  stoppe og gjenoppbygge seg selv, og agentene skal ikke ha Docker-tilgang.
+  Utløseren er merge til deploy-branchen — når agent-pipelinen selv har fått
+  en PR merget, plukker dette skriptet det opp (menneskelig review = gaten).
+
+  A/B-prinsipp uten parallellkjøring (innboksene er single-consumer, to
+  samtidige klynger dobbeltbehandler events):
+    1. Kjørende images beholdes som :rollback-tag.
+    2. Nye images bygges mens den gamle klyngen fortsatt kjører — byggefeil
+       er den vanligste «brick»-årsaken og gir her null nedetid.
+    3. Bytte (`docker compose up -d`) og helsesjekk: containerne kjører
+       stabilt uten restarts, og klar-meldinger dukker opp i loggene.
+    4. Ved feil rulles kode og images tilbake og forrige versjon startes.
+
+  Kø/state ligger i filer og navngitte volumer, så events i innboksene
+  overlever byttet.
+
+.PARAMETER Branch
+  Deploy-branchen som følges (default: v2.0). Arbeidskopien må stå på denne.
+
+.PARAMETER WatchSeconds
+  > 0: kjør i løkke og sjekk origin hvert n-te sekund (Ctrl+C stopper).
+
+.PARAMETER HealthTimeoutSeconds
+  Hvor lenge helsesjekken venter på klar-meldinger før den konkluderer.
+
+.PARAMETER Force
+  Fortsett selv om arbeidskopien har ukommitterte endringer (da gjøres ingen
+  automatisk `git reset` ved tilbakerulling).
+
+.EXAMPLE
+  pwsh scripts/self-update.ps1                     # én sjekk/oppgradering nå
+  pwsh scripts/self-update.ps1 -WatchSeconds 300   # poll hvert 5. minutt
+#>
+[CmdletBinding()]
+param(
+  [string]$Branch = "v2.0",
+  [int]$WatchSeconds = 0,
+  [int]$HealthTimeoutSeconds = 120,
+  [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path $PSScriptRoot -Parent
+
+function Write-Step([string]$Message) {
+  Write-Host "[self-update $(Get-Date -Format HH:mm:ss)] $Message"
+}
+
+# Klar-meldinger fra komponentene (best effort — brukes sammen med
+# stabilitetssjekken, ikke alene).
+$readyPattern = "Authenticated as|Connected via Socket Mode|integrations started|Watch-modus: poller"
+
+function Test-ClusterHealthy {
+  param([string]$SinceIso, [int]$TimeoutSeconds)
+
+  $services = @(docker compose config --services | Where-Object { $_ })
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $stableSamples = 0
+  $readySeen = $false
+
+  while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 5
+
+    $allRunning = $true
+    foreach ($svc in $services) {
+      $cid = @(docker compose ps -q $svc | Where-Object { $_ }) | Select-Object -First 1
+      if (-not $cid) { $allRunning = $false; continue }
+      $state = (docker inspect --format "{{.State.Status}} {{.RestartCount}}" $cid).Trim()
+      $status, $restarts = $state -split " "
+      if ([int]$restarts -gt 0 -or $status -in @("exited", "dead")) {
+        Write-Warning "Tjenesten '$svc' er '$status' (restarts: $restarts)."
+        return $false
+      }
+      if ($status -ne "running") { $allRunning = $false }
+    }
+    $stableSamples = $allRunning ? $stableSamples + 1 : 0
+
+    if (-not $readySeen) {
+      $logs = docker compose logs --no-color --since $SinceIso 2>$null
+      if ($logs -match $readyPattern) { $readySeen = $true }
+    }
+    if ($readySeen -and $stableSamples -ge 3) { return $true }
+  }
+
+  if ($stableSamples -ge 3) {
+    Write-Warning "Fant ingen klar-melding i loggene innen fristen, men alle containerne kjører stabilt — regner klyngen som frisk."
+    return $true
+  }
+  return $false
+}
+
+function Restore-Previous {
+  param([string]$OldSha, [bool]$WasClean, [string[]]$Images)
+
+  Write-Step "Ruller tilbake til $($OldSha.Substring(0, 7))..."
+  if ($WasClean) { git reset --hard $OldSha | Out-Null }
+  foreach ($img in $Images) {
+    $rollbackTag = "$($img.Split(':')[0]):rollback"
+    docker image inspect $rollbackTag *> $null
+    if ($LASTEXITCODE -eq 0) { docker tag $rollbackTag $img }
+  }
+  docker compose up -d --no-build --force-recreate
+  if ($LASTEXITCODE -ne 0) {
+    Write-Warning "Klarte ikke starte forrige versjon — manuell inngripen trengs (docker compose ps / logs)."
+  }
+}
+
+function Invoke-UpdatePass {
+  Push-Location $repoRoot
+  try {
+    $currentBranch = (git rev-parse --abbrev-ref HEAD).Trim()
+    if ($currentBranch -ne $Branch) {
+      throw "Arbeidskopien står på '$currentBranch', ikke deploy-branchen '$Branch'. Bytt branch eller angi -Branch."
+    }
+
+    git fetch origin $Branch --quiet
+    if ($LASTEXITCODE -ne 0) { throw "git fetch feilet." }
+
+    $localSha = (git rev-parse HEAD).Trim()
+    $remoteSha = (git rev-parse "origin/$Branch").Trim()
+    if ($localSha -eq $remoteSha) {
+      Write-Step "Allerede på siste versjon ($($localSha.Substring(0, 7)))."
+      return
+    }
+
+    $wasClean = -not (git status --porcelain)
+    if (-not $wasClean -and -not $Force) {
+      throw "Arbeidskopien har ukommitterte endringer — avbryter. (-Force for å overstyre; da gjøres ingen automatisk git-tilbakerulling.)"
+    }
+
+    Write-Step "Ny versjon på origin/${Branch}: $($localSha.Substring(0, 7)) -> $($remoteSha.Substring(0, 7))"
+
+    # 1. Behold kjørende images som :rollback før noe annet skjer.
+    $images = @(docker compose config --images | Where-Object { $_ } | Sort-Object -Unique)
+    foreach ($img in $images) {
+      docker image inspect $img *> $null
+      if ($LASTEXITCODE -eq 0) { docker tag $img "$($img.Split(':')[0]):rollback" }
+    }
+
+    git pull --ff-only origin $Branch --quiet
+    if ($LASTEXITCODE -ne 0) { throw "git pull --ff-only feilet — løs manuelt (divergert historikk?)." }
+
+    # 2. Bygg de nye imagene mens den gamle klyngen fortsatt kjører.
+    Write-Step "Bygger nye images (gammel klynge kjører fortsatt)..."
+    docker compose build
+    if ($LASTEXITCODE -ne 0) {
+      if ($wasClean) { git reset --hard $localSha | Out-Null }
+      throw "Bygging feilet — kjørende klynge er urørt$(if ($wasClean) { ', koden er rullet tilbake' })."
+    }
+
+    # 3. Bytt over og verifiser.
+    Write-Step "Bytter til ny versjon..."
+    $since = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    docker compose up -d
+    if ($LASTEXITCODE -ne 0) {
+      Restore-Previous -OldSha $localSha -WasClean $wasClean -Images $images
+      throw "docker compose up feilet — rullet tilbake til forrige versjon."
+    }
+
+    if (Test-ClusterHealthy -SinceIso $since -TimeoutSeconds $HealthTimeoutSeconds) {
+      Write-Step "Oppgradert til $($remoteSha.Substring(0, 7)) og verifisert."
+    } else {
+      # 4. Helsesjekk feilet: tilbake til forrige versjon.
+      Restore-Previous -OldSha $localSha -WasClean $wasClean -Images $images
+      throw "Helsesjekk feilet etter oppgradering — rullet tilbake til $($localSha.Substring(0, 7)). Se docker compose logs."
+    }
+  } finally {
+    Pop-Location
+  }
+}
+
+if ($WatchSeconds -gt 0) {
+  Write-Step "Watch-modus: sjekker origin/$Branch hvert ${WatchSeconds}. sekund (Ctrl+C stopper)."
+  while ($true) {
+    try { Invoke-UpdatePass } catch { Write-Warning $_.Exception.Message }
+    Start-Sleep -Seconds $WatchSeconds
+  }
+} else {
+  Invoke-UpdatePass
+}


### PR DESCRIPTION
## Bakgrunn

To driftsutfordringer:

1. `docker compose up --build` uten `-d` gir likevel containere med `restart: unless-stopped` (policyen er en egenskap ved containeren, ikke ved kjøringsmåten) — uønsket under utvikling i konsollen.
2. Når agent-pipelinen får merget en PR på seg selv, bør runtimen kunne oppgradere seg «i fart» uten å risikere å «bricke» seg selv.

## Løsning

**Dev-modus:** `restart: ${RESTART_POLICY:-unless-stopped}` i begge komponent-compose-filene. `scripts/dev.ps1` setter `RESTART_POLICY=no` og kjører `docker compose up --build` i forgrunnen — Ctrl+C stopper alt, ingenting starter igjen av seg selv. Default er uendret (`unless-stopped`), så vanlig drift overlever maskin-omstart.

**Selvoppgradering:** `scripts/self-update.ps1` kjører på hosten, utenfor det den oppgraderer (en container kan ikke trygt gjenoppbygge seg selv, og agentene skal ikke ha Docker-tilgang). Utløseren er merge til deploy-branchen — menneskelig review forblir gaten. A/B-prinsipp uten parallellkjøring (innboksene er single-consumer):

1. Kjørende images beholdes som `:rollback`-tag
2. `git pull --ff-only` (nekter ved skitten arbeidskopi) og bygging av nye images **mens gammel klynge fortsatt kjører** — byggefeil gir null nedetid
3. `docker compose up -d` + helsesjekk: stabil kjøring uten restarts og klar-meldinger i loggene
4. Ved feil: kode og images rulles tilbake, forrige versjon startes igjen

`-WatchSeconds 300` følger deploy-branchen kontinuerlig; alternativt Task Scheduler.

## Verifisert

- `docker compose config` gir `restart: unless-stopped` uten env-var og `restart: 'no'` med `RESTART_POLICY=no`
- Begge skriptene parserer feilfritt (PowerShell AST-parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)