### PR TITLE
Fiks: monter junior-agentens triggers-katalog i integrations-containeren

### DIFF
--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,13 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-22** — Fiks: PR #55 glemte volumlinja for junior-agentens
+  `triggers/` i `integrations/docker-compose.yml`, så integrations krasjet
+  ved oppstart med `EACCES: mkdir /agents/local-cc-jr-developer` (køen
+  prøvde å opprette rutekatalogen i containerens rot-eide `/agents`).
+  Én mount-linje per rute i `AGENT_ROUTES` er kontrakten — nå dokumentert
+  av feilen også.
+
 - **2026-07-22** — Junior-kodeagent (issue #53): ny agent
   `local-cc-jr-developer` — Claude Code CLI mot lokal modell via LM Studios
   Anthropic-kompatible API (`scripts/junior-agent.ps1` setter env og starter

--- a/integrations/docker-compose.yml
+++ b/integrations/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       # aldri hele agents/-treet, som ville eksponert agentenes .env-filer.
       # Legg til én linje per rute: ../agents/<navn>/triggers:/agents/<navn>/triggers
       - ../agents/local-cc-coding-agent/triggers:/agents/local-cc-coding-agent/triggers
+      - ../agents/local-cc-jr-developer/triggers:/agents/local-cc-jr-developer/triggers
       # Egen state (pending replies + results-offset) overlever restart
       - integrations-state:/state
     # Overstyrbar for utvikling i forgrunnen (scripts/dev.ps1 setter "no");


### PR DESCRIPTION
## Hva

Én volumlinje i `integrations/docker-compose.yml`:

```yaml
- ../agents/local-cc-jr-developer/triggers:/agents/local-cc-jr-developer/triggers
```

## Hvorfor

PR #55 la `local-cc-jr-developer` inn i `AGENT_ROUTES` (`.env.example`), men glemte mount-linja i compose-fila. Kontrakten er én mount per rute (`/agents/<navn>/triggers`); uten den prøvde `AgentQueue.init` å opprette katalogen som ekte katalog i containerens rot-eide `/agents` og integrations krasjet ved oppstart:

```
ERROR [main] Fatal error during startup. Error: EACCES: permission denied, mkdir '/agents/local-cc-jr-developer'
```

Katalogen finnes på hosten (`agents/local-cc-jr-developer/triggers/` med `.gitkeep` fra PR #55) — den var bare ikke synlig inne i containeren.

Merk: issue #53 sin «Berørte filer»-liste nevnte heller ikke compose-fila — spesifikasjonsglipp, ikke bare implementasjonsglipp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)