### PR TITLE
PR-prosess: CODEOWNERS + auto-merge på trygge stier, menneske-review på sensitive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# CODEOWNERS — plattform-håndhevet skille mellom trygge og sensitive stier.
+#
+# Med branch protection «Require review from Code Owners» (og required
+# approvals: 0) betyr en linje her: PR-er som rører stien krever menneskelig
+# godkjenning før merge. PR-er som ikke rører noen av stiene kan merges uten
+# approver — det er grunnlaget for auto-merge-prosessen.
+# Se doc/pr-prosess.md for hele prosessen og hvorfor stiene er valgt
+# (merge til deploy-branchen er auto-deploy via scripts/self-update.ps1).
+
+# Agent-instrukser og skills — styrer agentenes oppførsel
+agents/*/CLAUDE.md            @olebhansen
+agents/*/docker/skills/       @olebhansen
+agents/*/docker/entrypoint.sh @olebhansen
+
+# Sikkerhetsmodell og drift. Hele integrations/src/ er sensitiv i første
+# omgang (CI er kun typecheck); kan snevres til config.ts når testdekning
+# er på plass.
+integrations/src/             @olebhansen
+**/docker-compose.yml         @olebhansen
+**/Dockerfile                 @olebhansen
+scripts/                      @olebhansen
+
+# Denne prosessen selv (CODEOWNERS + workflows)
+.github/                      @olebhansen

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,30 @@
+# Auto-merge av PR-er agentene har merket «auto-merge».
+#
+# Merging krever Contents write — det skal agent-tokenene aldri ha. Derfor
+# gjøres selve mergen her, med workflowens efemere GITHUB_TOKEN; agentene
+# trenger bare rettigheter til å sette labelen. `gh pr merge --auto` slår på
+# GitHubs native auto-merge, som venter til alle required checks er grønne.
+#
+# Branch protection gjelder også denne workflowen: rører PR-en en
+# CODEOWNERS-sti, blokkeres merge til code owner (mennesket) har godkjent —
+# labelen kan aldri omgå det. Se doc/pr-prosess.md.
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: github.event.label.name == 'auto-merge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slå på auto-merge for PR-en
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --squash --auto "$PR_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# Minimal CI — ment som required status check i branch protection, slik at
+# «grønn CI» er plattform-håndhevet før auto-merge (se doc/pr-prosess.md).
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [v2.0, main]
+
+permissions:
+  contents: read
+
+jobs:
+  integrations:
+    name: integrations
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: integrations
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: integrations/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck

--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ Merk:
   prosjektnavnet, så pending replies og results-offsets overlever bytte av
   klone.
 
+## PR-prosess: auto-merge på trygge stier
+
+Alle endringer leveres som PR, men ikke alle trenger et menneske: PR-er som
+kun rører trygge stier kan agentene merge selv — de kjører en
+reviewer-subagent, poster reviewen som PR-kommentar, og setter labelen
+`auto-merge`; en GitHub Action merger med den efemere `GITHUB_TOKEN` når
+required checks er grønne (agent-tokenene har fortsatt ingen kode-tilgang).
+Sensitive stier — agent-instrukser (`agents/*/CLAUDE.md`), skills,
+Docker-filer, `integrations/src/`, `scripts/` og `.github/` — har menneskelig
+eier i [`.github/CODEOWNERS`](.github/CODEOWNERS), og branch protection
+(«Require review from Code Owners») blokkerer merge til code owner har
+godkjent, uansett label. Husk at merge til deploy-branchen er auto-deploy
+via self-update-watcheren — derfor er lista konservativ. Hele prosessen,
+inkludert branch protection-oppsettet for repo-admin, er beskrevet i
+[`doc/pr-prosess.md`](doc/pr-prosess.md).
+
 ## Legge til en ny agent
 
 Pipelinen utvides ved å legge nye agenter under `agents/<navn>/`. En agent er

--- a/doc/index.md
+++ b/doc/index.md
@@ -20,6 +20,8 @@ kronologisk endringslogg.
   læringsloop)
 - [plans/agent-delegering.md](plans/agent-delegering.md) — delegering mellom
   agenter via broen, og utførende kodeagent (local-cc-coding-agent)
+- [pr-prosess.md](pr-prosess.md) — auto-merge på trygge stier,
+  CODEOWNERS/menneske-review på sensitive (issue #54)
 
 ## Overordnet kunnskap
 

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,17 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-22** — PR-prosess (issue #54): plattform-håndhevet skille mellom
+  trygge og sensitive endringer. `.github/CODEOWNERS` legger menneskelig
+  eier på agent-instrukser, skills, entrypoints, `integrations/src/`,
+  Docker-filer, `scripts/` og `.github/`; sammen med branch protection
+  (approvals 0 + Require review from Code Owners + required check) kan
+  trygge PR-er auto-merges: agenten kjører reviewer-subagent, poster
+  reviewen som PR-kommentar og setter labelen `auto-merge` — en workflow
+  merger med efemer `GITHUB_TOKEN` (agent-tokens har fortsatt ingen
+  Contents-tilgang). Minimal CI (`ci.yml`, typecheck i integrations) som
+  required check. Se [pr-prosess.md](pr-prosess.md).
+
 - **2026-07-22** — Fiks: PR #55 glemte volumlinja for junior-agentens
   `triggers/` i `integrations/docker-compose.yml`, så integrations krasjet
   ved oppstart med `EACCES: mkdir /agents/local-cc-jr-developer` (køen

--- a/doc/pr-prosess.md
+++ b/doc/pr-prosess.md
@@ -1,0 +1,82 @@
+---
+type: process
+title: PR-prosess — auto-merge på trygge stier, menneske-review på sensitive
+description: Plattform-håndhevet skille mellom trygge endringer (reviewer-subagent + auto-merge) og sensitive endringer (CODEOWNERS krever menneskelig godkjenning). Én agent-identitet, ingen Contents-tilgang for agent-tokens.
+timestamp: 2026-07-22T00:00:00Z
+---
+
+# PR-prosess: auto-merge på trygge stier
+
+## Hvorfor
+
+Agent-pipelinen skal kunne utbedre seg selv uten at hvert eneste
+dokumentasjons- eller småfiks-PR venter på et menneske — men endringer som
+styrer *agentenes egen oppførsel* eller *sikkerhetsmodellen* skal alltid ha
+menneskelig godkjenning. Bakgrunn (issue #54): i PR #47 blokkerte
+kodeagentens tillatelses-klassifiserer redigering av dens egen instruksfil —
+riktig instinkt, men skillet bør håndheves av plattformen, ikke av den
+enkelte agentens dømmekraft.
+
+**Viktig premiss:** merge til deploy-branchen er auto-deploy innen minutter
+([scripts/self-update.ps1](../scripts/self-update.ps1) med `-WatchSeconds`).
+Auto-merge på trygge stier er dermed auto-deploy uten menneske i løkka —
+helsesjekk + rollback fanger krasj, men ikke uønsket oppførsel. Listen over
+sensitive stier er satt med det i mente.
+
+## Mekanikken — én identitet, fire brikker
+
+1. **[`.github/CODEOWNERS`](../.github/CODEOWNERS)** legger menneskelig eier
+   på sensitive stier: agent-instrukser (`agents/*/CLAUDE.md`), skills,
+   entrypoints, `integrations/src/`, Docker-filer, `scripts/` og `.github/`
+   selv.
+2. **Branch protection på deploy-branchen** (settes av repo-admin, se under):
+   required approvals **0** + **Require review from Code Owners** + required
+   status check (CI). Kombinasjonen gir nøyaktig skillet:
+   - PR uten CODEOWNERS-treff → kan merges uten noen godkjenning.
+   - PR som rører en sensitiv sti → blokkert til code owner har godkjent.
+3. **CI som required check**
+   ([`.github/workflows/ci.yml`](../.github/workflows/ci.yml), minimal:
+   typecheck i `integrations/`) — «grønn CI før merge» er plattform-håndhevet,
+   ikke konvensjon.
+4. **Auto-merge via GitHub Action**
+   ([`.github/workflows/auto-merge.yml`](../.github/workflows/auto-merge.yml)):
+   når en PR får labelen `auto-merge`, slår workflowen på GitHubs native
+   auto-merge med den efemere `GITHUB_TOKEN`. Merging krever Contents write —
+   det har bare workflowen, aldri agent-tokenene. Labelen kan ikke omgå
+   branch protection: rører PR-en en sensitiv sti, venter mergen på code
+   owner uansett.
+
+## Prosessen for agentene
+
+Før en agent setter `auto-merge`-labelen på sin egen PR skal den:
+
+1. Kjøre en **reviewer-subagent** på diffen (ferske øyne, ikke samme
+   kontekst som skrev koden).
+2. Poste reviewens funn og konklusjon som **kommentar på PR-en** — det er
+   audit-sporet for at review faktisk er gjort.
+3. Først da sette labelen: `gh pr edit <nr> --add-label auto-merge`.
+
+Rører PR-en en sensitiv sti er labelen virkningsløs (og bør utelates) —
+pek i stedet på PR-en i svaret til brukeren, som før: mennesket er
+review-gaten.
+
+## Oppsett (repo-admin, gjøres i GitHub UI/API)
+
+Dette kan ikke leveres som filer i repoet:
+
+1. **Branch protection / ruleset på `v2.0`** (og senere `main`):
+   - Require a pull request before merging, **required approvals: 0**
+   - **Require review from Code Owners: enabled**
+   - Required status checks: **`integrations`** (jobben i CI-workflowen)
+2. **Repo-innstilling:** «Allow auto-merge» må være slått på (kreves av
+   `gh pr merge --auto`).
+3. **Label:** opprett `auto-merge` i repoet
+   (`gh label create auto-merge --repo digdir/digdir-ai-agents`).
+
+## Grenser og videre
+
+- `integrations/src/` er sensitiv i sin helhet i første omgang, siden CI kun
+  er typecheck; kan snevres til `config.ts` når testdekning finnes.
+- Merges gjort av `GITHUB_TOKEN` trigger ikke andre workflows — irrelevant
+  her, siden deploy er polling-basert (self-update-watcheren), ikke en
+  Action.


### PR DESCRIPTION
Closes #54

Plattform-håndhevet skille mellom trygge og sensitive endringer, med én agent-identitet og uten Contents-tilgang for agent-tokens.

## Innhold

- **`.github/CODEOWNERS`** — menneskelig eier (@olebhansen) på agent-instrukser (`agents/*/CLAUDE.md`), skills, entrypoints, `integrations/src/`, Docker-filer, `scripts/` og `.github/` selv. Jf. issuets vurderingspunkt: hele `integrations/src/` er sensitiv i første omgang (CI er kun typecheck og merge = auto-deploy); kan snevres til `config.ts` når testdekning finnes.
- **`.github/workflows/ci.yml`** — minimal CI (`npm ci` + `npm run typecheck` i `integrations/`), ment som required status check. Verifisert lokalt: typecheck går grønt på branchen.
- **`.github/workflows/auto-merge.yml`** — trigges av labelen `auto-merge`, kjører `gh pr merge --squash --auto` med efemer `GITHUB_TOKEN` (`contents: write, pull-requests: write`). GitHubs native auto-merge venter på required checks; branch protection/CODEOWNERS kan aldri omgås av labelen.
- **`doc/pr-prosess.md`** (+ README-seksjon, index, logg) — hele prosessen for mennesker og agenter, inkl. auto-deploy-risikoen via self-update.

## Akseptansekriterier

- [x] `.github/CODEOWNERS` på plass med riktige stier
- [x] `ci.yml` og `auto-merge.yml` implementert
- [x] Ingen agent-tokens trenger utvidet Contents-tilgang (merge skjer via `GITHUB_TOKEN` i Action)
- [x] Prosessen dokumentert for mennesker og agenter (`doc/pr-prosess.md`, README)
- [ ] Prosess-instruks i agentenes `CLAUDE.md` — **blokkert, se under**

## Blokkert: prosess-instruks i agentenes CLAUDE.md

Tillatelses-klassifisereren blokkerer (helt riktig, og som i PR #47) at kodeagenten redigerer `agents/*/CLAUDE.md` — nettopp skillet denne PR-en plattform-håndhever. Reviewer må legge inn denne seksjonen manuelt i **`agents/local-cc-coding-agent/CLAUDE.md`** og **`agents/local-cc-jr-developer/CLAUDE.md`** (etter «Arbeidsområde og git»):

```markdown
## Auto-merge av trygge PR-er

PR-er som **ikke** rører noen sti i `.github/CODEOWNERS` (agent-instrukser,
skills, Docker-filer, `integrations/src/`, `scripts/`, `.github/`) kan
merges uten menneskelig godkjenning — se `doc/pr-prosess.md`. Prosessen er:

1. Kjør en reviewer-subagent på PR-diffen — ferske øyne, ikke samme
   kontekst som skrev koden.
2. Post reviewens funn og konklusjon som kommentar på PR-en
   (`gh pr comment`) — kommentaren er audit-sporet.
3. Er reviewen ren: sett labelen `auto-merge`
   (`gh pr edit <nr> --add-label auto-merge`). En GitHub Action merger når
   required checks er grønne.

Rører PR-en en sensitiv sti, er labelen virkningsløs (branch protection
krever code owner uansett) — utelat den og pek på PR-en i `reply` som før.
Husk: merge til deploy-branchen er auto-deploy innen minutter.
```

## Oppsett som må gjøres av repo-admin (kan ikke leveres som filer)

1. Branch protection/ruleset på `v2.0`: Require a pull request (approvals **0**) + **Require review from Code Owners** + required status check **`integrations`** (jobben i `ci.yml`).
2. Repo-innstilling **Allow auto-merge** på (kreves av `gh pr merge --auto`).
3. Opprett labelen: `gh label create auto-merge --repo digdir/digdir-ai-agents`.

Detaljer i `doc/pr-prosess.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
