### PR TITLE
Slack: håndter kun reaksjoner boten er involvert i (issue #61)

### DIFF
--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,14 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-22** — Slack-reaksjoner filtreres (issue #61): `onReaction` i
+  `SlackConnector` håndterer nå kun reaksjoner på botens egne meldinger eller
+  i tråder boten deltar i — før la den working-reaksjon på alt i alle kanaler
+  den var medlem av. Teksthentingen for reaksjons-eventer bruker
+  `conversations.replies` i stedet for `conversations.history`, som ikke ser
+  trådsvar («fant ikke meldingsteksten»); samme kall gir tråddeltakelsen, og
+  filteret evalueres før noen reaksjon legges på.
+
 - **2026-07-22** — Førstelinje-router i integrations (issue #52): innkommende
   events annoteres med `classification` (action/feedback/ack/delegate — ett
   strukturert kall mot en liten lokal modell) og `related_activities`

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -20,8 +20,10 @@ an inbound webhook endpoint, so it can run entirely from your laptop.
   message (they are all directed at the bot).
 - In **channels, private groups, group DMs and threads** → it only reacts when
   the bot is **@-mentioned**. Other messages are ignored.
-- It also picks up **emoji reactions** on any message (`reaction_added`). When
-  the queue bridge is on, the reaction and the message it sits on are handed to
+- It also picks up **emoji reactions** (`reaction_added`) — but only on the
+  bot's **own messages** or in **threads the bot participates in**; reactions
+  elsewhere in channels it happens to be a member of are ignored. When the
+  queue bridge is on, the reaction and the message it sits on are handed to
   the agent, which interprets what the reaction means (e.g. a 👍 as positive
   feedback). The bot ignores its own reactions to avoid loops.
 

--- a/integrations/src/slack/connector.ts
+++ b/integrations/src/slack/connector.ts
@@ -241,10 +241,12 @@ export class SlackConnector {
   }
 
   /**
-   * Handles emoji reactions on any message: the reaction (and the message it
-   * sits on) is handed to the agent, which interprets what it means (e.g. a 👍
-   * as a positive-feedback / learning signal). The agent's classification then
-   * drives the response via the normal result flow.
+   * Handles emoji reactions on messages the bot is involved with: reactions on
+   * the bot's own messages, or on messages in threads where the bot
+   * participates. The reaction (and the message it sits on) is handed to the
+   * agent, which interprets what it means (e.g. a 👍 as a positive-feedback /
+   * learning signal). Reactions elsewhere in channels the bot happens to be a
+   * member of are ignored (issue #61).
    */
   private async onReaction(event: SlackReactionEvent): Promise<void> {
     // Skip our own reactions — the bot adds thinking_face/ack reactions itself,
@@ -260,12 +262,29 @@ export class SlackConnector {
 
     const channel = event.item.channel;
     const messageTs = event.item.ts;
+
+    // Filter before touching the message: only reactions on the bot's own
+    // messages, or in threads the bot already participates in. This must
+    // happen before the working reaction below — reacting first is exactly
+    // the noisy behavior the filter exists to stop.
+    const onOwnMessage = this.selfUserId !== undefined && event.item_user === this.selfUserId;
+    const context = await this.fetchThreadContext(channel, messageTs);
+    const inOwnThread =
+      context !== null && this.selfUserId !== undefined && context.authors.has(this.selfUserId);
+    if (!onOwnMessage && !inOwnThread) {
+      log.debug(
+        `Skipping reaction :${event.reaction}: on ${channel}@${messageTs} — not on our message or in a thread we participate in.`,
+      );
+      return;
+    }
+
     const by = event.item_user ? ` (message by ${event.item_user})` : "";
     log.info(`Picked up reaction :${event.reaction}: from ${event.user ?? "?"} on ${channel}@${messageTs}${by}.`);
 
     if (!this.queue) return; // Observe-only when the bridge is off.
 
-    const { text, threadTs } = await this.fetchMessageText(channel, messageTs);
+    const text = context?.text ?? "";
+    const threadTs = context?.threadTs ?? messageTs;
 
     // Show the working reaction on the reacted-to message while the agent runs.
     const willClear = this.awaitReply;
@@ -302,21 +321,40 @@ export class SlackConnector {
     );
   }
 
-  /** Fetches the text (and thread root) of a single message by channel + ts. */
-  private async fetchMessageText(channel: string, ts: string): Promise<{ text: string; threadTs: string }> {
+  /**
+   * Fetches the reacted-to message plus the thread it lives in. Uses
+   * `conversations.replies` rather than `conversations.history`: history only
+   * returns top-level messages, so a reacted-to thread reply came back empty
+   * ("fant ikke meldingsteksten", issue #61). Returns null when the lookup
+   * fails entirely.
+   */
+  private async fetchThreadContext(
+    channel: string,
+    ts: string,
+  ): Promise<{ text: string; threadTs: string; authors: Set<string> } | null> {
     try {
-      const res = await this.web.conversations.history({
-        channel,
-        latest: ts,
-        oldest: ts,
-        inclusive: true,
-        limit: 1,
-      });
-      const msg = (res.messages as Array<{ text?: string; thread_ts?: string }> | undefined)?.[0];
-      return { text: msg?.text ?? "", threadTs: msg?.thread_ts ?? ts };
+      let messages = await this.fetchReplies(channel, ts);
+      const target = messages.find((m) => m.ts === ts) ?? messages[0];
+      const threadTs = target?.thread_ts ?? ts;
+      // Given a reply's ts, Slack may return only that reply — re-fetch from
+      // the thread root so `authors` reflects the whole conversation.
+      if (threadTs !== ts && !messages.some((m) => m.ts === threadTs)) {
+        messages = await this.fetchReplies(channel, threadTs);
+      }
+      const authors = new Set<string>();
+      for (const m of messages) if (m.user) authors.add(m.user);
+      return { text: target?.text ?? "", threadTs, authors };
     } catch (err) {
-      log.warn("Could not fetch the reacted-to message text.", err);
-      return { text: "", threadTs: ts };
+      log.warn("Could not fetch the reacted-to message/thread.", err);
+      return null;
     }
+  }
+
+  private async fetchReplies(
+    channel: string,
+    ts: string,
+  ): Promise<Array<{ ts?: string; user?: string; text?: string; thread_ts?: string }>> {
+    const res = await this.web.conversations.replies({ channel, ts, limit: 100 });
+    return (res.messages ?? []) as Array<{ ts?: string; user?: string; text?: string; thread_ts?: string }>;
   }
 }

--- a/integrations/src/slack/connector.ts
+++ b/integrations/src/slack/connector.ts
@@ -354,7 +354,14 @@ export class SlackConnector {
     channel: string,
     ts: string,
   ): Promise<Array<{ ts?: string; user?: string; text?: string; thread_ts?: string }>> {
-    const res = await this.web.conversations.replies({ channel, ts, limit: 100 });
-    return (res.messages ?? []) as Array<{ ts?: string; user?: string; text?: string; thread_ts?: string }>;
+    const allMessages: Array<{ ts?: string; user?: string; text?: string; thread_ts?: string }> = [];
+    let cursor: string | undefined;
+    do {
+      const res = await this.web.conversations.replies({ channel, ts, limit: 100, cursor });
+      const messages = (res.messages ?? []) as Array<{ ts?: string; user?: string; text?: string; thread_ts?: string }>;
+      allMessages.push(...messages);
+      cursor = res.response_metadata?.next_cursor as string | undefined;
+    } while (cursor);
+    return allMessages;
   }
 }


### PR DESCRIPTION
Closes #61

Stopper botens støyete reaksjonsatferd: `onReaction` i `SlackConnector` håndterer nå kun reaksjoner **på botens egne meldinger** (`item_user` = botens user-id) eller **i tråder boten deltar i** (noen melding i tråden er forfattet av boten). Reaksjoner ellers i kanaler boten tilfeldigvis er medlem av ignoreres stille (debug-logg).

## Innhold

- **Filteret evalueres før working-reaksjonen legges på** — å reagere først var selve støyproblemet issuet beskriver.
- **`conversations.replies` erstatter `conversations.history`** i teksthentingen (ny `fetchThreadContext`): history returnerer kun toppnivåmeldinger, så reaksjoner på trådsvar ga «fant ikke meldingsteksten». Samme kall gir forfatterlista som tråddeltakelses-filteret trenger, så filter + tekst koster normalt ett API-kall (to når reaksjonen står på et trådsvar og Slack ikke returnerer rota i første svar).
- **Fail-closed:** feiler tråd-oppslaget helt, behandles reaksjonen bare hvis den står på botens egen melding (samme tekst-fallback som før: «(fant ikke meldingsteksten)», tråd = meldingen selv). Å droppe i tvilstilfeller er riktig retning for et støyfilter.
- Docs: `integrations/README.md` (reaksjonsavsnittet) og `doc/log.md`.

## Scope-notat

`conversations.replies` krever de samme `*:history`-scopene som `conversations.history` — ingen nye Slack-scopes trengs.

## Verifisering

- `npm run typecheck` grønn.
- Logikken er ellers ren API-interaksjon; ende-til-ende-verifisering (reaksjon i fremmed tråd ignoreres, reaksjon på trådsvar får med teksten) må gjøres mot et levende Slack-workspace ved utrulling.

## Relatert

Issue #65 (samtalekontekst i Slack-eventer) omtaler samme `conversations.replies`-svakhet — `fetchThreadContext` her kan gjenbrukes der.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack emoji reactions are now processed only when they target the bot’s messages or conversations involving the bot.
  * Thread context is used to provide more relevant reaction handling and responses.

* **Bug Fixes**
  * Prevented unrelated emoji reactions from triggering the bot or adding processing indicators.

* **Documentation**
  * Updated integration documentation and change logs to describe the refined reaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->