### PR TITLE
Junior-agent: sett ANTHROPIC_SMALL_FAST_MODEL til lokal modell

### DIFF
--- a/scripts/junior-agent.ps1
+++ b/scripts/junior-agent.ps1
@@ -16,6 +16,9 @@
 $env:ANTHROPIC_BASE_URL = "http://127.0.0.1:1234"
 $env:ANTHROPIC_AUTH_TOKEN = "lmstudio"
 $env:ANTHROPIC_MODEL = "ornith-1.0-35b-nvfp4-mtp"
+# Uten denne går Claude Codes bakgrunnskall mot et claude-*-modellnavn som
+# ikke finnes i LM Studio; pek dem på samme lokale modell.
+$env:ANTHROPIC_SMALL_FAST_MODEL = "ornith-1.0-35b-nvfp4-mtp"
 
 Push-Location (Join-Path (Split-Path $PSScriptRoot -Parent) "agents\local-cc-jr-developer")
 try {


### PR DESCRIPTION
## Hva

Setter `ANTHROPIC_SMALL_FAST_MODEL` til samme lokale Ornith-variant som hovedmodellen i `scripts/junior-agent.ps1`.

## Hvorfor

Claude Code bruker small/fast-modellen til bakgrunnskall (titler, oppsummeringer m.m.). Uten overstyring ber CLI-en LM Studio om et `claude-*`-modellnavn som ikke finnes der, og kallene feiler. Nevnt under «Husk» i #58.

Verifisert på big-boi 2026-07-22: med begge variablene satt fullfører `claude -p` en enkel oppgave med verktøybruk mot `ornith-1.0-35b-nvfp4-mtp` (etter template-fiksen i #58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)