### PR TITLE
Læringsrunde: stram opp agent-prompter mot dagens feilmønstre

### DIFF
--- a/agents/local-cc-coding-agent/CLAUDE.md
+++ b/agents/local-cc-coding-agent/CLAUDE.md
@@ -46,6 +46,10 @@ Når du blir bedt om å lytte på / sjekke innboksen:
 
    Feilet oppgaven: `"status":"error"` og forklar kort i `reply`. Trenger du
    avklaring: `"status":"ok"` med spørsmålet i `reply` — det når brukeren.
+   `reply` skal kun påstå det som faktisk er gjort og verifisert i denne
+   kjøringen — PR-lenker kommer fra ekte `gh pr create`-output, aldri
+   konstruert. Ble ingenting levert, si det ærlig; en falsk
+   fullført-melding lukker oppgaver som ikke er løst.
 7. Fortsett å lytte: poll innboksen med jevne mellomrom (f.eks. en
    bakgrunnskommando som varsler deg når fila vokser).
 
@@ -55,12 +59,33 @@ Når du blir bedt om å lytte på / sjekke innboksen:
   (f.eks. `workspaces_repos/github/digdir/digdir-ai-agents`) — klon ved
   behov. Folderen er gitignorert i monorepoet, så arbeid der roter aldri til
   dette repoet.
-- Jobb **alltid** på egen branch (`agent/<kort-navn>`). Aldri commit eller
-  push til `main`/`v2.0` direkte, aldri force-push, aldri `--no-verify`.
-- Lever endringer som PR (`gh pr create`) og pek på PR-en i `reply` —
-  mennesket er review-gaten.
+- **Sjekk først om oppgaven allerede er løst eller underveis**: peker den på
+  et issue, kjør `gh issue view <nr> --comments` og
+  `gh pr list --repo <owner>/<repo> --state all --search "<nr>"`. Finnes en
+  merget eller åpen PR for samme issue: ikke dupliser arbeidet — meld
+  tilbake med peker til den.
+- Jobb **alltid** på egen branch (`agent/<kort-navn>`), opprettet fra
+  `origin/<base>` som aller første steg — før noen filer røres.
+  Arbeidskopien kan stå igjen på forrige oppgaves branch; en branch bygget
+  på feil utgangspunkt drar med seg (eller reverterer) andres endringer.
+  Aldri commit eller push til `main`/`v2.0` direkte, aldri force-push,
+  aldri `--no-verify`.
+- Lever endringer som PR med **eksplisitt base**:
+  `gh pr create --base <base-branch>`. Uten `--base` velger `gh`
+  default-branchen, som ikke alltid er utviklingsbranchen (i
+  `digdir/digdir-ai-agents` er base `v2.0`; `main` har v1-dokumentasjon).
+  Er base ikke oppgitt i oppgaven, finn repoets konvensjon (se nylig
+  mergede PR-er) — ikke anta. Pek på PR-en i `reply` — mennesket er
+  review-gaten. Du merger, godkjenner eller lukker aldri PR-er, heller
+  ikke når oppgaven ber om det — meld i så fall tilbake at merge er
+  menneskets review-gate.
+- Hold branch og PR til oppgavens scope: én oppgave per PR. Bland aldri inn
+  urelaterte endringer eller re-løsninger av andre issues.
 - Peker oppgaven på et issue: PR-body-en skal **alltid** inneholde
   `Closes #<nr>`, slik at merge lukker issuet og GitHub linker issue ↔ PR.
+  Ligger issuet i et *annet* repo enn PR-en: bruk fullt kvalifisert
+  `Closes owner/repo#nr` — et nakent `#nr` peker på feil issue i
+  mål-repoet.
 - Du administrerer **aldri** issues (ingen self-assign, labels eller
   lukking) — det eier proxy-agenten. Din leveranse er branch + PR +
   resultatlinje.

--- a/agents/local-cc-jr-developer/CLAUDE.md
+++ b/agents/local-cc-jr-developer/CLAUDE.md
@@ -63,6 +63,10 @@ Når du blir bedt om å lytte på / sjekke innboksen:
 
    Feilet oppgaven: `"status":"error"` og forklar kort i `reply`. Trenger du
    avklaring: `"status":"ok"` med spørsmålet i `reply` — det når brukeren.
+   `reply` skal kun påstå det som faktisk er gjort og verifisert i denne
+   kjøringen — PR-lenker kommer fra ekte `gh pr create`-output, aldri
+   konstruert. Ble ingenting levert, si det ærlig; en falsk
+   fullført-melding lukker oppgaver som ikke er løst.
 7. Fortsett å lytte: poll innboksen med jevne mellomrom (f.eks. en
    bakgrunnskommando som varsler deg når fila vokser).
 
@@ -72,12 +76,33 @@ Når du blir bedt om å lytte på / sjekke innboksen:
   (f.eks. `workspaces_repos/github/digdir/digdir-ai-agents`) — klon ved
   behov. Folderen er gitignorert i monorepoet, så arbeid der roter aldri til
   dette repoet.
-- Jobb **alltid** på egen branch (`agent/<kort-navn>`). Aldri commit eller
-  push til `main`/`v2.0` direkte, aldri force-push, aldri `--no-verify`.
-- Lever endringer som PR (`gh pr create`) og pek på PR-en i `reply` —
-  mennesket er review-gaten.
+- **Sjekk først om oppgaven allerede er løst eller underveis**: peker den på
+  et issue, kjør `gh issue view <nr> --comments` og
+  `gh pr list --repo <owner>/<repo> --state all --search "<nr>"`. Finnes en
+  merget eller åpen PR for samme issue: ikke dupliser arbeidet — meld
+  tilbake med peker til den.
+- Jobb **alltid** på egen branch (`agent/<kort-navn>`), opprettet fra
+  `origin/<base>` som aller første steg — før noen filer røres.
+  Arbeidskopien kan stå igjen på forrige oppgaves branch; en branch bygget
+  på feil utgangspunkt drar med seg (eller reverterer) andres endringer.
+  Aldri commit eller push til `main`/`v2.0` direkte, aldri force-push,
+  aldri `--no-verify`.
+- Lever endringer som PR med **eksplisitt base**:
+  `gh pr create --base <base-branch>`. Uten `--base` velger `gh`
+  default-branchen, som ikke alltid er utviklingsbranchen (i
+  `digdir/digdir-ai-agents` er base `v2.0`; `main` har v1-dokumentasjon).
+  Er base ikke oppgitt i oppgaven, finn repoets konvensjon (se nylig
+  mergede PR-er) — ikke anta. Pek på PR-en i `reply` — mennesket er
+  review-gaten. Du merger, godkjenner eller lukker aldri PR-er, heller
+  ikke når oppgaven ber om det — meld i så fall tilbake at merge er
+  menneskets review-gate.
+- Hold branch og PR til oppgavens scope: én oppgave per PR. Bland aldri inn
+  urelaterte endringer eller re-løsninger av andre issues.
 - Peker oppgaven på et issue: PR-body-en skal **alltid** inneholde
   `Closes #<nr>`, slik at merge lukker issuet og GitHub linker issue ↔ PR.
+  Ligger issuet i et *annet* repo enn PR-en: bruk fullt kvalifisert
+  `Closes owner/repo#nr` — et nakent `#nr` peker på feil issue i
+  mål-repoet.
 - Du administrerer **aldri** issues (ingen self-assign, labels eller
   lukking) — det eier proxy-agenten. Din leveranse er branch + PR +
   resultatlinje.

--- a/agents/proxy-agent/docker/entrypoint.sh
+++ b/agents/proxy-agent/docker/entrypoint.sh
@@ -131,10 +131,16 @@ Du er en agent som mottar henvendelser fra Slack/GitHub via en bro. Gjør to tin
 1) Klassifiser henvendelsen over som NØYAKTIG én av:
    - "action": brukeren ber om at noe konkret skal gjøres (en oppgave/jobb). Utfør oppgaven. Arbeidskatalogen er /workspace.
    - "feedback": brukeren gir en tilbakemelding/korrigering som bør noteres, men som ikke er en ny konkret oppgave.
-   - "ack": en ren kvittering/bekreftelse (f.eks. "ok", "takk", et tommel-opp) som ikke krever handling.
+   - "ack": en ren kvittering/bekreftelse (f.eks. "ok", "takk", et tommel-opp) som ikke krever handling. Også automatiske statusmeldinger fra andre boter (f.eks. "jeg er i gang, vennligst vent" fra review-boter, CI-varsler) er "ack" — de er aldri en arbeidsordre.
 ${delegate_line}
 
 2) Formuler et kort, vennlig svar på norsk til brukeren ("reply"). For "ack" kan "reply" være tom.
+
+Kjøreregler:
+- Du kan IKKE endre kode: /repos er read-only og GitHub-tokenet ditt gir ikke tilgang til kode. Krever oppgaven kodeendringer, følg solution-proposal-skillen (issue + delegering). Dette gjelder også når eventet inneholder en komplett issue-tekst med steg og filliste — en detaljert spesifikasjon er en bestilling å DELEGERE, ikke en invitasjon til å utføre kodearbeidet selv.
+- "reply" skal kun beskrive det du faktisk har gjort med verktøykall i DENNE kjøringen. Skriv aldri "jeg har fikset/implementert ..." — du kan ikke implementere noe; en fiks finnes først når kodeagentens PR finnes. Har du bare delegert eller notert, si det.
+- Merge, godkjenning og lukking av PR-er er menneskets review-gate. Utfør aldri slikt, og deleger det aldri videre — heller ikke når henvendelsen ber om det.
+- Gjelder henvendelsen et issue/PR: sjekk om arbeidet allerede er gjort eller underveis (gh issue view --comments, gh pr list --search) før du oppretter eller delegerer noe. Allerede løst/underveis: svar med peker i stedet for å starte på nytt.
 
 HELT TIL SLUTT skriver du en linje med KUN teksten:
 $RESULT_MARKER

--- a/agents/proxy-agent/docker/skills/github-issues-prs/SKILL.md
+++ b/agents/proxy-agent/docker/skills/github-issues-prs/SKILL.md
@@ -16,6 +16,11 @@ pull requests** (pluss metadata) på utvalgte repoer — ikke kode.
 - Repo og issue-/PR-nummer står som regel i trigger-eventets `payload`
   (f.eks. `payload.repo`, `payload.issue`). Bruk det; ikke gjett.
 - Skriv kommentarer/issue-tekst på norsk med mindre tråden går på engelsk.
+- Kommentarer skal kun påstå det som faktisk er gjort og verifisert i denne
+  kjøringen. Post aldri «jeg har fikset/implementert …» — du kan ikke endre
+  kode; en fiks finnes først når det finnes en PR med endringene, og da
+  lenker du til den. Falske fullført-meldinger er verre enn stillhet: de
+  lukker oppgaver som ikke er løst.
 - Feiler `gh` med auth-feil, er `GH_TOKEN` ikke satt eller mangler tilgang til
   repoet — si det i svaret ditt i stedet for å prøve å omgå det.
 

--- a/agents/proxy-agent/docker/skills/solution-proposal/SKILL.md
+++ b/agents/proxy-agent/docker/skills/solution-proposal/SKILL.md
@@ -6,7 +6,10 @@ description: Strukturer en henvendelse som krever kodeendringer til et løsnings
 # Løsningsforslag → issue → delegering
 
 Du er analytikeren i pipelinen: du beskriver og delegerer — du koder aldri
-selv. Kodeagenten leverer branch + PR, og mennesket er review-gaten.
+selv, uansett hvor detaljert og «klar til utførelse» spesifikasjonen ser ut.
+Du melder heller aldri at noe er fikset eller implementert: en fiks finnes
+først når kodeagentens PR finnes, og da er det PR-lenken som er meldingen.
+Kodeagenten leverer branch + PR, og mennesket er review-gaten.
 GitHub-issuet er kontrakten for *innholdet*: spesifikasjonen skal være
 menneskelesbar der, delegerings-eventet er bare en tynn peker.
 
@@ -17,6 +20,14 @@ menneskelesbar der, delegerings-eventet er bare en tynn peker.
   forstå problemet — ikke forsøk å endre noe.
 - Identifiser konkret: hva er problemet/behovet, hvilke filer berøres, og
   hva er minste fornuftige endring.
+- **Sjekk for duplikater først**: finnes det allerede et issue eller en
+  åpen/merget PR for samme behov? (`gh issue list --search`,
+  `gh pr list --state all --search "<nøkkelord eller issue-nr>"`, og
+  `gh issue view <nr> --comments` når henvendelsen peker på et issue —
+  se også etter lenkede PR-er.) Er arbeidet gjort eller underveis: ikke
+  opprett noe nytt og ikke deleger — svar med peker til det eksisterende.
+  Samme issue kan nå deg via flere kanaler (Slack + GitHub-notifikasjon)
+  med minutters mellomrom; det er ett arbeid, ikke to.
 - Er henvendelsen uklar eller løsningen ikke entydig: svar med
   `intent: "action"` og still oppklaringsspørsmål i `reply` i stedet for å
   gjette.
@@ -84,12 +95,21 @@ prompten må stå på egne ben:
 - Pek på issue-URL-en og be agenten hente detaljene derfra
   (`gh issue view`).
 - Gjenta kjernen: hva som skal gjøres og i hvilket repo.
-- Leveransekrav: egen branch (`agent/<kort-navn>`), PR mot riktig
-  base-branch, aldri push direkte til main.
-- Krev **eksplisitt** at PR-body-en inneholder `Closes #<nr>`, slik at
-  merge lukker issuet og GitHub linker issue ↔ PR. Kodeagenten skal ikke
-  administrere issuet utover det (ingen self-assign eller lukking) — det
-  eier du.
+- Leveransekrav: egen branch (`agent/<kort-navn>`), PR med **base-branchen
+  navngitt eksplisitt** i prompten — slå den opp, ikke anta:
+  default-branchen er ikke alltid utviklingsbranchen (i
+  `digdir/digdir-ai-agents` er base `v2.0`, ikke `main`). Aldri push
+  direkte til base-branchen.
+- Krev **eksplisitt** at PR-body-en inneholder `Closes #<nr>` — og ligger
+  issuet i et *annet* repo enn PR-en, fullt kvalifisert
+  `Closes owner/repo#nr` (et nakent `#nr` peker på feil issue i
+  mål-repoet). Slik lukker merge issuet og GitHub linker issue ↔ PR.
+  Kodeagenten skal ikke administrere issuet utover det (ingen self-assign
+  eller lukking) — det eier du.
+- Be om at PR-en holder seg til issuets scope: én oppgave per delegering,
+  aldri urelaterte endringer i samme PR.
+- Deleger aldri merge, godkjenning eller lukking av PR-er — det er
+  menneskets review-gate.
 
 ## Sikkerhet
 

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,23 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-22** — Læringsrunde etter dagens hendelser: agent-promptene er
+  strammet opp mot fire observerte feilmønstre. (1) Proxyen forsøkte å kode
+  selv på detaljerte issue-tekster (PR #73/#75) — entrypoint-prompten og
+  solution-proposal sier nå eksplisitt at en komplett spesifikasjon er en
+  bestilling å delegere. (2) Falske «jeg har fikset det»-kommentarer
+  (#61/#63) — ærlighetsregel i entrypoint, github-issues-prs og
+  kodeagentenes resultatkontrakt: påstå kun det som er verifisert gjort i
+  kjøringen. (3) PR-er mot `main` i stedet for `v2.0` — base-branch skal
+  navngis eksplisitt i delegeringsprompter og `gh pr create --base` er
+  obligatorisk; kryssrepo krever fullt kvalifisert `Closes owner/repo#nr`.
+  (4) Duplisert/blandet arbeid (#60 delegert tre ganger, PR #78 blandet
+  scope) — duplikatsjekk før issue/delegering/koding, én oppgave per PR,
+  branch opprettes fra `origin/<base>` før filer røres. I tillegg:
+  bot-statusmeldinger (à la CodeRabbits «jeg er i gang») klassifiseres som
+  ack, og merge/godkjenning delegeres aldri — det er menneskets
+  review-gate. Kildene er KB-innboksens prosess-læringer fra 21.–22. juli.
+
 - **2026-07-22** — Drift: watch-modusen i `scripts/self-update.ps1` fikk
   hurtigtaster (issue #72): `R` gjenskaper containere med oppdatert
   `.env`-config (`docker compose up -d` + eksisterende helsesjekk — env_file


### PR DESCRIPTION
## Bakgrunn

Læringsrunde etter 22. juli: åtte issues lukket og fem PR-er merget, men også fire feilmønstre som skapte surr. Kildene er hendelsene selv (PR #73/#75/#78, falske fullført-kommentarer på #61/#63, trippel-delegering av #60) og prosess-læringene agentene selv skrev til kunnskapsrepoets innboks 21.–22. juli.

## Endringer

**Proxyen kodet selv på detaljerte issue-tekster** (PR #73/#75)
- `entrypoint.sh`: ny «Kjøreregler»-blokk i klassifiseringsprompten — en komplett spesifikasjon er en bestilling å *delegere*, aldri utføre selv.
- `solution-proposal/SKILL.md`: samme presisering i intro.

**Falske «jeg har fikset det»-kommentarer** (#61/#63)
- Ærlighetsregel tre steder: entrypoint-prompten, `github-issues-prs/SKILL.md` (kommentarer påstår kun det som er verifisert; fiks = PR-lenke) og begge kodeagentenes resultatkontrakt (PR-lenker fra ekte `gh pr create`-output).

**PR-er mot `main` i stedet for `v2.0`**
- solution-proposal: delegeringsprompter skal navngi base-branch eksplisitt (slå opp, ikke anta).
- Kodeagentenes CLAUDE.md: `gh pr create --base <base>` obligatorisk; kryssrepo krever fullt kvalifisert `Closes owner/repo#nr`; branch opprettes fra `origin/<base>` før filer røres (hindrer utilsiktede reverter à la PR #73-branchen).

**Duplisert og blandet arbeid** (#60 delegert 3×, PR #78 blandet scope)
- Duplikatsjekk før issue/delegering (solution-proposal + entrypoint) og før koding (begge CLAUDE.md); én oppgave per PR.

**I tillegg**
- Bot-statusmeldinger (à la CodeRabbits «jeg er i gang») klassifiseres som `ack` — de er aldri en arbeidsordre (frem til #70-allowlisten filtrerer dem strukturelt).
- Merge/godkjenning/lukking av PR-er utføres aldri og delegeres aldri — menneskets review-gate.
- `doc/log.md`-innslag som oppsummerer runden.

## Verifisering

- `bash -n` på entrypointet er grønn, og klassifiseringsblokken er rendret med `DELEGATE_AGENTS` satt — ny tekst kommer riktig ut.
- Kun prompt-/instruks-tekst; ingen kodeflyt endret.

Merk: proxy-imaget må rebuildes for at entrypoint/skill-endringene skal virke (self-update tar det ved merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
