### PR TITLE
Sikkerhet: hard allowlist for GitHub-initierte agent-aksjoner (fail-closed)

### DIFF
--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,17 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-22** — Sikkerhet: hard allowlist for GitHub-initierte
+  agent-aksjoner (issue #70): kun logins i `GITHUB_ALLOWED_USERS` kan utløse
+  arbeidsordrer fra GitHub. Aktøren slås opp per notifikasjon før alt annet
+  (assign → siste `assigned`-event; mention → forfatteren av innholdet som
+  blir prompten). Ikke på lista: WARN-logg med aktør/repo/issue/reason, tråd
+  markert lest, ingen reaksjon/kø/router-kall. Fail-closed: tom liste (med
+  oppstartsadvarsel) eller feilet aktør-oppslag dropper eventet. Botens egne
+  hendelser skippes fortsatt stille på debug-nivå (#63). Restrisiko
+  (innholds-injection via godkjente brukere) dokumentert i
+  integrations/README.
+
 - **2026-07-22** — Læringsrunde etter dagens hendelser: agent-promptene er
   strammet opp mot fire observerte feilmønstre. (1) Proxyen forsøkte å kode
   selv på detaljerte issue-tekster (PR #73/#75) — entrypoint-prompten og

--- a/integrations/.env.example
+++ b/integrations/.env.example
@@ -20,6 +20,13 @@ GITHUB_TOKEN=
 # in either variable and leave the other blank.
 GITHUB_TOKEN_CLASSIC_NOTIFICATIONS=
 
+# Hard allowlist (fail-closed): comma-separated GitHub logins allowed to
+# trigger agent actions (mentions/assigns). Comparison is case-insensitive.
+# Empty = NO ONE can trigger actions — every GitHub work order is dropped and
+# a warning is logged at startup. Do not list the bot's own account; its own
+# events are always skipped quietly as self-triggered noise.
+GITHUB_ALLOWED_USERS=
+
 # Emoji used to acknowledge an @-mention when NO answer is posted back
 # (queue bridge off, or AGENT_POST_RESULTS=false).
 # One of GitHub's allowed reactions: +1 -1 laugh confused heart hooray rocket eyes

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -12,13 +12,26 @@ an inbound webhook endpoint, so it can run entirely from your laptop.
   the issue is handed to the agent queue, same as a mention.
 - When the bot is **@-mentioned** in a comment or body → it reacts with 🚀
   (`rocket`, configurable) on the triggering comment (or the issue/PR itself).
-- Self-triggered assignment events (where the bot assigned itself) are
-  recognized by checking the actor from the issue events API and are skipped
-  (debug-logged), so the bot never loops on its own self-assignments. For
-  mention/team_mention events, the actor cannot be reliably determined from
-  the notification payload (latest_comment_url can point to stale comments),
-  so all mentions are treated as human-triggered. If the actor lookup fails,
-  the event is treated as human-triggered (work orders are never dropped silently).
+- **Hard allowlist (fail-closed):** only logins listed in
+  `GITHUB_ALLOWED_USERS` can trigger agent actions. The actor behind every
+  relevant notification is looked up before anything else — for assigns the
+  actor on the last `assigned` event (issue events API), for mentions the
+  author of the exact content that becomes the prompt (the triggering
+  comment, or the issue/PR body when there is none). Events from anyone else
+  are dropped with a WARN log (actor, repo, issue, reason) and the thread is
+  marked read — **no reaction, no queue, no router call**, so the bot never
+  signals that it saw the event. An empty/unset list drops *all* GitHub work
+  orders (a startup warning says so), and a failed actor lookup also drops
+  the event (fail-closed).
+- Self-triggered events (where the bot itself is the actor) are recognized
+  the same way and skipped quietly (debug-logged) — they are noise, not an
+  attack. The bot's own account should not be on the allowlist.
+- **Residual risk** (gated elsewhere, by design): the allowlist gates
+  *initiation*, not *content*. An allowed user can still point the agent at
+  text written by a stranger (an issue body, a linked page), and prompt
+  injection may live there. Defence in depth stays as before: delegated
+  prompts and event text are treated as untrusted data, agent tokens carry no
+  Contents access, and a human review gate covers sensitive paths.
 
 **Slack** (connects over Socket Mode — a websocket, no public URL needed):
 - On start it sets its presence to **active** (green dot); on shutdown it sets

--- a/integrations/src/config.ts
+++ b/integrations/src/config.ts
@@ -15,6 +15,12 @@ export interface GithubConfig {
   ackReaction: string;
   pollIntervalSeconds: number;
   apiBaseUrl: string;
+  /**
+   * GitHub logins allowed to trigger agent actions, lowercased (logins are
+   * case-insensitive). The gate is fail-closed: an empty list means every
+   * GitHub-initiated work order is dropped.
+   */
+  allowedUsers: string[];
 }
 
 export interface SlackConfig {
@@ -122,6 +128,14 @@ export function loadConfig(): Config {
     ackReaction: (process.env.GITHUB_ACK_REACTION ?? "+1").trim(),
     pollIntervalSeconds: Number(process.env.GITHUB_POLL_INTERVAL ?? "60"),
     apiBaseUrl: (process.env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/+$/, ""),
+    allowedUsers: [
+      ...new Set(
+        (process.env.GITHUB_ALLOWED_USERS ?? "")
+          .split(",")
+          .map((s) => s.trim().toLowerCase())
+          .filter((s) => s !== ""),
+      ),
+    ],
   };
 
   const slack: SlackConfig = {

--- a/integrations/src/github/poller.ts
+++ b/integrations/src/github/poller.ts
@@ -55,6 +55,13 @@ export class GithubPoller {
   async start(signal: AbortSignal): Promise<void> {
     this.login = await this.client.getAuthenticatedLogin();
     log.info(`Authenticated as ${this.login}. Polling notifications every ${this.config.pollIntervalSeconds}s (min).`);
+    if (this.config.allowedUsers.length === 0) {
+      log.warn(
+        "GITHUB_ALLOWED_USERS is empty — no GitHub user can trigger agent actions; " +
+          "every GitHub work order will be dropped (fail-closed). Set a comma-separated " +
+          "list of allowed logins to open the gate.",
+      );
+    }
     this.running = true;
 
     while (this.running && !signal.aborted) {
@@ -111,6 +118,14 @@ export class GithubPoller {
       return; // Leave unhandled reasons unread; do not mark as handled.
     }
 
+    // Hard allowlist gate (fail-closed, issue #70): only listed humans may
+    // trigger agent actions, so the actor behind every relevant notification
+    // must be determined first. For assigns that is the actor on the last
+    // `assigned` event; for mentions/team_mentions it is the author of the
+    // exact content that would become the prompt (the triggering comment, or
+    // the issue/PR body when there is none) — the gate covers what actually
+    // gets executed. A failed lookup leaves the actor null, which drops the
+    // event below: work orders from an unverifiable actor are never queued.
     let actorLogin: string | null = null;
     try {
       if (n.reason === "assign") {
@@ -123,26 +138,44 @@ export class GithubPoller {
             this.login,
           );
         }
+      } else {
+        const sourceUrl = n.subject.latest_comment_url ?? n.subject.url;
+        if (sourceUrl) {
+          actorLogin = await this.client.getResourceAuthor(sourceUrl);
+        }
       }
-      // For mentions/team_mentions, the actor is not reliably attributable from
-      // the notification payload — latest_comment_url can point to a stale bot
-      // comment even when a human triggered the notification (e.g., by editing
-      // the issue body). Therefore, we do NOT attempt to infer the actor and
-      // leave it null, treating all mention/team_mention events as human-triggered.
     } catch (err) {
-      log.warn(
-        `Could not determine actor for ${n.reason} on ${where}; proceeding as human-triggered to be safe.`,
-        err,
-      );
+      log.warn(`Could not determine actor for ${n.reason} on ${where}; dropping (fail-closed).`, err);
     }
 
     if (actorLogin === this.login) {
+      // The bot's own events are noise, not an attack — skip quietly.
       log.debug(`Skipping self-triggered ${n.reason} on ${where}.`);
       this.handled.add(key);
       try {
         await this.client.markThreadRead(n.id);
       } catch (err) {
         log.warn(`Could not mark self-triggered thread read on ${n.repository.full_name}; retrying next poll.`, err);
+      }
+      return;
+    }
+
+    const allowed =
+      actorLogin !== null && this.config.allowedUsers.includes(actorLogin.toLowerCase());
+    if (!allowed) {
+      // Security trail: WARN with actor, repo, issue and reason. No reaction,
+      // no queue, no router call — the bot must not signal that it saw the
+      // event; the thread is only marked read so it stops resurfacing.
+      const issueNum = issueNumberFrom(n.subject.url);
+      log.warn(
+        `Dropping ${n.reason} on ${n.repository.full_name}#${issueNum ?? "?"} ` +
+          `("${n.subject.title}"): actor "${actorLogin ?? "unknown"}" is not in GITHUB_ALLOWED_USERS.`,
+      );
+      this.handled.add(key);
+      try {
+        await this.client.markThreadRead(n.id);
+      } catch (err) {
+        log.warn(`Could not mark dropped thread read on ${n.repository.full_name}; retrying next poll.`, err);
       }
       return;
     }

--- a/integrations/src/github/poller.ts
+++ b/integrations/src/github/poller.ts
@@ -148,7 +148,7 @@ export class GithubPoller {
       log.warn(`Could not determine actor for ${n.reason} on ${where}; dropping (fail-closed).`, err);
     }
 
-    if (actorLogin === this.login) {
+    if (actorLogin?.toLowerCase() === this.login.toLowerCase()) {
       // The bot's own events are noise, not an attack — skip quietly.
       log.debug(`Skipping self-triggered ${n.reason} on ${where}.`);
       this.handled.add(key);


### PR DESCRIPTION
Closes #70

GitHub-polleren gater nå alle arbeidsordrer bak en hard allowlist: kun logins i `GITHUB_ALLOWED_USERS` kan utløse agent-aksjoner. Gaten ligger **før alt annet** — før reaksjon, før router, før kø — og er **fail-closed**.

## Innhold

- **Config** (`config.ts`): `GITHUB_ALLOWED_USERS` — kommaseparert, case-insensitiv (lowercases ved innlesing), dedupes. Tom liste er gyldig konfig, men gir tydelig WARN ved oppstart («ingen GitHub-brukere kan utløse aksjoner») og dropper alle GitHub-arbeidsordrer. Sikkerhetsfilteret er ikke opt-in.
- **Poller** (`poller.ts`): aktøren slås opp per relevant notifikasjon:
  - *assign* → aktøren på siste `assigned`-event (eksisterende `getLastAssigner` fra #63/#74).
  - *mention/team_mention* → forfatteren av **innholdet som blir prompten** (`latest_comment_url`, ellers issue/PR-body via `subject.url`) — gaten dekker dermed nøyaktig det som faktisk ville blitt eksekvert.
  - Aktør ikke på lista → WARN med aktør/repo/issue/reason (sikkerhetssporet), tråden markeres lest, **ingen reaksjon, ingen kø, ingen router-kall** — boten signaliserer ikke at den så hendelsen.
  - Feiler aktør-oppslaget → drop med WARN (fail-closed), aldri kø «for sikkerhets skyld».
  - Botens egne hendelser skippes fortsatt stille på debug-nivå (#63-semantikken beholdt, sjekkes før allowlisten).
- **Docs**: `.env.example` (ny variabel), `integrations/README.md` (sikkerhetsmodell + restrisiko), `doc/log.md`.

## Merknad om mentions

v2.0 sluttet bevisst å utlede aktør for mentions fordi `latest_comment_url` kan peke på en foreldet bot-kommentar (fail-open den gangen). Med fail-closed snus avveiningen: gaten sjekker forfatteren av samme ressurs som `enqueueWorkOrder` henter prompt-teksten fra, så «foreldet bot-kommentar»-tilfellet betyr nå at bot-forfattet innhold aldri blir prompt — det var nettopp den vektoren som ga den falske merge-ordren på PR #74 (jf. #76/#83).

## Restrisiko (dokumentert i README, løses ikke her)

Allowlisten gater *initiering*, ikke *innhold*: en godkjent bruker kan fortsatt peke agenten på fremmed tekst. Forsvar i dybden som før — event-tekst behandles som upålitelig, agent-tokens uten Contents-tilgang, menneskelig review-gate.

## Verifisering

- `npm run typecheck` grønn.
- Diff mot `v2.0` er kun de fem filene over.

## Utrulling

Etter merge må `GITHUB_ALLOWED_USERS` settes i `integrations/.env` (f.eks. `olebhansen`) — ellers dropper polleren alle GitHub-arbeidsordrer (med oppstartsadvarsel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an allowlist for GitHub accounts permitted to trigger agent actions through mentions and assignments.
  - Matching is case-insensitive, and events from unapproved accounts are ignored without triggering reactions or processing.
  - The integration now fails closed when no approved accounts are configured.
  - The bot’s own GitHub events continue to be skipped quietly.

- **Documentation**
  - Updated configuration guidance and security documentation, including residual risks related to content from approved accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->