### PR TITLE
integrations: kortslutt ack i køen når routeren har klassifisert (#64)

### DIFF
--- a/agents/proxy-agent/docker/entrypoint.sh
+++ b/agents/proxy-agent/docker/entrypoint.sh
@@ -142,6 +142,10 @@ Kjøreregler:
 - Merge, godkjenning og lukking av PR-er er menneskets review-gate. Utfør aldri slikt, og deleger det aldri videre — heller ikke når henvendelsen ber om det.
 - Gjelder henvendelsen et issue/PR: sjekk om arbeidet allerede er gjort eller underveis (gh issue view --comments, gh pr list --search) før du oppretter eller delegerer noe. Allerede løst/underveis: svar med peker i stedet for å starte på nytt.
 
+Kontekst fra routeren (valgfritt):
+- Hvis eventet har feltet "classification" (med verdi "action", "feedback", "ack" eller "delegate"), er det en forhåndsvurdering gjort av integrasjonenes første-linje-router. Bruk den som hint, men klassifiser likevel selv — routeren kan feile og sende inn eventer uten denne merkingen.
+- Hvis eventet har feltet "related_activities", inneholder det lister med lignende åpne aktiviteter (Slack-tråder eller GitHub-issues) funnet av routerens embedding-søk. Bruk dem som kontekst for å vurdere duplikater; ikke la dem bestemme klassifiseringen.
+
 HELT TIL SLUTT skriver du en linje med KUN teksten:
 $RESULT_MARKER
 og deretter ett JSON-objekt (kan gå over flere linjer):

--- a/integrations/.env.example
+++ b/integrations/.env.example
@@ -176,3 +176,9 @@ ROUTER_TIMEOUT_MS=10000
 # max number of matches annotated per event.
 ROUTER_MATCH_THRESHOLD=0.7
 ROUTER_MAX_RELATED=3
+
+# Event types (comma-separated) that the router classifies as "ack" or similar
+# should be short-circuited: delivered directly via the connector (ack reaction +
+# working-reaction cleanup) without appending to the agent's inbox — i.e. they
+# never wake proxy-agent. Empty = short-circuit disabled; default is "ack".
+ROUTER_SHORT_CIRCUIT=ack

--- a/integrations/.env.example
+++ b/integrations/.env.example
@@ -177,8 +177,9 @@ ROUTER_TIMEOUT_MS=10000
 ROUTER_MATCH_THRESHOLD=0.7
 ROUTER_MAX_RELATED=3
 
-# Event types (comma-separated) that the router classifies as "ack" or similar
-# should be short-circuited: delivered directly via the connector (ack reaction +
-# working-reaction cleanup) without appending to the agent's inbox — i.e. they
-# never wake proxy-agent. Empty = short-circuit disabled; default is "ack".
+# Short-circuit for ack-classified events: when set to "ack", events the router
+# classifies as "ack" are delivered directly via the connector (ack reaction +
+# working-reaction cleanup) without appending to the agent's inbox — they never
+# wake proxy-agent. Empty = short-circuit disabled. Only "ack" or empty is
+# accepted; other values are normalized to empty (disabled). Default: "ack".
 ROUTER_SHORT_CIRCUIT=ack

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -144,6 +144,15 @@ same machine).
 - Empty `ROUTER_BASE_URL` (the default) disables all of this; events are
   queued exactly as before.
 
+- **Short-circuit** (`ROUTER_SHORT_CIRCUIT`, default `"ack"`): when the router
+  classifies an event with a value listed here, integrations delivers it
+  directly through the connector (adds ack reaction, clears working reaction)
+  and skips appending to `inbox.jsonl` — proxy-agent never wakes. Empty env var
+  disables short-circuit; comma-separated list allowed (`"ack"` or
+  `"action,feedback,ack"`). This is purely an optimization: if a classified
+  event still gets queued (router failed / no classification), the agent's
+  own classification step will still see it and act accordingly.
+
 ## Requirements
 
 - **Node ≥ 23** (runs the TypeScript directly via type stripping — no build step),

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -145,13 +145,13 @@ same machine).
   queued exactly as before.
 
 - **Short-circuit** (`ROUTER_SHORT_CIRCUIT`, default `"ack"`): when the router
-  classifies an event with a value listed here, integrations delivers it
-  directly through the connector (adds ack reaction, clears working reaction)
-  and skips appending to `inbox.jsonl` — proxy-agent never wakes. Empty env var
-  disables short-circuit; comma-separated list allowed (`"ack"` or
-  `"action,feedback,ack"`). This is purely an optimization: if a classified
-  event still gets queued (router failed / no classification), the agent's
-  own classification step will still see it and act accordingly.
+  classifies an event as `"ack"`, integrations delivers it directly through the
+  connector (adds ack reaction, clears working reaction) and skips appending to
+  `inbox.jsonl` — proxy-agent never wakes. Empty env var disables short-circuit;
+  only `"ack"` or empty is accepted (other values are normalized to empty). This
+  is purely an optimization: if a classified event still gets queued (router
+  failed / no classification), the agent's own classification step will still
+  see it and act accordingly.
 
 ## Requirements
 

--- a/integrations/src/agent/queue.ts
+++ b/integrations/src/agent/queue.ts
@@ -7,7 +7,7 @@ import type { SlackConnector } from "../slack/connector.ts";
 import type { GithubPoller } from "../github/poller.ts";
 import type { Delivery, QueueEvent, ReplyContext, ResultLine, ResultPosters } from "./types.ts";
 
-type Connectors = { slack: SlackConnector; github: GithubPoller };
+type Connectors = { slack?: SlackConnector; github?: GithubPoller };
 
 const log = createLogger("queue");
 
@@ -103,19 +103,17 @@ export class AgentQueue {
     // or timeout the event goes through unannotated, exactly as before.
     const enriched = this.router ? await this.router.annotate(event) : event;
 
-    // Short-circuit: if the router classified this as an ack (or another type
-    // listed in ROUTER_SHORT_CIRCUIT), deliver it directly via the connectors —
-    // add the ack reaction and clear the working reaction, without waking
-    // proxy-agent or appending to inbox. Falls back to normal queuing when:
+    // Short-circuit: if the router classified this as an ack, deliver it
+    // directly via the connectors — add the ack reaction and clear the working
+    // reaction, without waking proxy-agent or appending to inbox. Falls back to
+    // normal queuing when:
     //   - shortCircuit is disabled (empty env var)
     //   - the router did not run / failed (no classification)
-    //   - the event's classification does not match a short-circuit type
-    if (this.config.routerShortCircuit && enriched.classification && this.connectors) {
-      const allowed = this.config.routerShortCircuit.split(",").map((s) => s.trim()).filter(Boolean);
-      if (allowed.includes(enriched.classification)) {
-        await this.deliverAckDirectly(reply, enriched.id);
-        return;
-      }
+    //   - the event's classification is not exactly "ack"
+    if (this.config.routerShortCircuit && enriched.classification === "ack" && this.connectors) {
+      const delivered = await this.deliverAckDirectly(reply, enriched.id);
+      if (delivered) return;
+      // Failed delivery: continue to normal queue path below.
     }
 
     await fs.appendFile(this.config.inboxFile, JSON.stringify(enriched) + "\n", "utf8");
@@ -126,13 +124,13 @@ export class AgentQueue {
 
   /**
    * Delivers an ack directly via the connectors (ack reaction + working-reaction
-   * cleanup) without touching inbox.jsonl. Logs each attempt so the outcome is
-   * visible at startup — a failed ack must not leave a stale working reaction,
-   * but it also must not throw.
+   * cleanup) without touching inbox.jsonl. Returns true on success, false on
+   * failure (so the caller can fall back to normal queuing). Logs each attempt
+   * so the outcome is visible.
    */
-  private async deliverAckDirectly(reply: ReplyContext, id: string): Promise<void> {
+  private async deliverAckDirectly(reply: ReplyContext, id: string): Promise<boolean> {
     const connectors = this.connectors;
-    if (!connectors) return;
+    if (!connectors) return false;
 
     try {
       if (reply.kind === "slack" && connectors.slack) {
@@ -141,15 +139,16 @@ export class AgentQueue {
         await connectors.github.deliver(reply, { kind: "ack" });
       } else {
         log.warn(`No connector for ack delivery of "${id}" (${reply.kind}).`);
-        return;
+        return false;
       }
     } catch (err) {
       log.error(`Failed to short-circuit ack for "${id}"; will fall back to normal queuing.`, err);
+      return false;
     }
 
     // Best effort: if we delivered successfully, drop the pending entry — there
-    // is no agent result coming for this event. If delivery failed (above), leave
-    // it so the next poll cycle picks it up through the normal queue path.
+    // is no agent result coming for this event. If delivery failed (above), we
+    // returned false and the caller will append to inbox.jsonl.
     try {
       this.pending.delete(id);
       await this.persistPending();
@@ -158,6 +157,7 @@ export class AgentQueue {
     }
 
     log.info(`Short-circuited ack for event "${id}" (${reply.kind}).`);
+    return true;
   }
 
   /**

--- a/integrations/src/agent/queue.ts
+++ b/integrations/src/agent/queue.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import type { AgentQueueConfig, AgentRoute } from "../config.ts";
 import { createLogger } from "../logger.ts";
 import type { Router } from "../router/router.ts";
+import type { SlackConnector } from "../slack/connector.ts";
+import type { GithubPoller } from "../github/poller.ts";
 import type { Delivery, QueueEvent, ReplyContext, ResultLine, ResultPosters } from "./types.ts";
+
+type Connectors = { slack: SlackConnector; github: GithubPoller };
 
 const log = createLogger("queue");
 
@@ -34,6 +38,8 @@ export class AgentQueue {
   private readonly pendingFile: string;
   /** Optional first-line router; annotates external events before the append. */
   private readonly router: Router | null;
+  /** Connectors wired up after construction so submit() can short-circuit acks directly. */
+  private connectors: Connectors | null = null;
 
   constructor(config: AgentQueueConfig, router: Router | null = null) {
     this.config = config;
@@ -48,6 +54,16 @@ export class AgentQueue {
       },
       ...config.routes,
     ];
+  }
+
+  /**
+   * Wires the Slack and GitHub connectors into the queue so ack events can be
+   * delivered directly (ack reaction + working-reaction cleanup) without going
+   * through inbox.jsonl. Must be called after the connectors are constructed in
+   * main(); called with null to drop them again.
+   */
+  setConnectors(connectors: Connectors | null): void {
+    this.connectors = connectors;
   }
 
   /** The primary agent keeps the historic offset filename; routes get their own. */
@@ -86,10 +102,62 @@ export class AgentQueue {
     // activities before the append. annotate() never throws — on any failure
     // or timeout the event goes through unannotated, exactly as before.
     const enriched = this.router ? await this.router.annotate(event) : event;
+
+    // Short-circuit: if the router classified this as an ack (or another type
+    // listed in ROUTER_SHORT_CIRCUIT), deliver it directly via the connectors —
+    // add the ack reaction and clear the working reaction, without waking
+    // proxy-agent or appending to inbox. Falls back to normal queuing when:
+    //   - shortCircuit is disabled (empty env var)
+    //   - the router did not run / failed (no classification)
+    //   - the event's classification does not match a short-circuit type
+    if (this.config.routerShortCircuit && enriched.classification && this.connectors) {
+      const allowed = this.config.routerShortCircuit.split(",").map((s) => s.trim()).filter(Boolean);
+      if (allowed.includes(enriched.classification)) {
+        await this.deliverAckDirectly(reply, enriched.id);
+        return;
+      }
+    }
+
     await fs.appendFile(this.config.inboxFile, JSON.stringify(enriched) + "\n", "utf8");
     this.pending.set(enriched.id, reply);
     await this.persistPending();
     log.info(`Queued ${enriched.source} event "${enriched.id}" for the agent.`);
+  }
+
+  /**
+   * Delivers an ack directly via the connectors (ack reaction + working-reaction
+   * cleanup) without touching inbox.jsonl. Logs each attempt so the outcome is
+   * visible at startup — a failed ack must not leave a stale working reaction,
+   * but it also must not throw.
+   */
+  private async deliverAckDirectly(reply: ReplyContext, id: string): Promise<void> {
+    const connectors = this.connectors;
+    if (!connectors) return;
+
+    try {
+      if (reply.kind === "slack" && connectors.slack) {
+        await connectors.slack.deliver(reply, { kind: "ack" });
+      } else if (reply.kind === "github" && connectors.github) {
+        await connectors.github.deliver(reply, { kind: "ack" });
+      } else {
+        log.warn(`No connector for ack delivery of "${id}" (${reply.kind}).`);
+        return;
+      }
+    } catch (err) {
+      log.error(`Failed to short-circuit ack for "${id}"; will fall back to normal queuing.`, err);
+    }
+
+    // Best effort: if we delivered successfully, drop the pending entry — there
+    // is no agent result coming for this event. If delivery failed (above), leave
+    // it so the next poll cycle picks it up through the normal queue path.
+    try {
+      this.pending.delete(id);
+      await this.persistPending();
+    } catch {
+      // Persist failure is not fatal — pending survives in memory across cycles.
+    }
+
+    log.info(`Short-circuited ack for event "${id}" (${reply.kind}).`);
   }
 
   /**

--- a/integrations/src/config.ts
+++ b/integrations/src/config.ts
@@ -73,11 +73,12 @@ export interface AgentQueueConfig {
   /** Upper bound on a posted reply's length; longer output is truncated. */
   maxReplyChars: number;
   /**
-   * Short-circuit event types that the connector should deliver directly (add
-   * ack reaction, clear working reaction) without queuing in the agent's
-   * inbox — events classified with one of these values bypass the queue and
-   * never wake proxy-agent. Empty = short-circuit disabled; comma-separated
-   * list allowed, e.g. "ack". Default: "ack".
+   * Short-circuit for ack-classified events: when set to "ack", the connector
+   * delivers ack-classified events directly (add ack reaction, clear working
+   * reaction) without queuing in the agent's inbox — acks bypass the queue and
+   * never wake proxy-agent. Empty = short-circuit disabled. Only "ack" or empty
+   * string is accepted; other values are normalized to empty (disabled).
+   * Default: "ack".
    */
   routerShortCircuit: string;
 }
@@ -191,7 +192,10 @@ export function loadConfig(): Config {
     resultsPollIntervalSeconds: Number(process.env.AGENT_RESULTS_POLL_INTERVAL ?? "5"),
     postResults: bool(process.env.AGENT_POST_RESULTS, true),
     maxReplyChars: Number(process.env.AGENT_MAX_REPLY_CHARS ?? "12000"),
-    routerShortCircuit: (process.env.ROUTER_SHORT_CIRCUIT ?? "ack").trim(),
+    routerShortCircuit: (() => {
+      const raw = (process.env.ROUTER_SHORT_CIRCUIT ?? "ack").trim();
+      return raw === "" || raw === "ack" ? raw : "";
+    })(),
   };
 
   if (agentQueue.enabled) {

--- a/integrations/src/config.ts
+++ b/integrations/src/config.ts
@@ -72,6 +72,14 @@ export interface AgentQueueConfig {
   postResults: boolean;
   /** Upper bound on a posted reply's length; longer output is truncated. */
   maxReplyChars: number;
+  /**
+   * Short-circuit event types that the connector should deliver directly (add
+   * ack reaction, clear working reaction) without queuing in the agent's
+   * inbox — events classified with one of these values bypass the queue and
+   * never wake proxy-agent. Empty = short-circuit disabled; comma-separated
+   * list allowed, e.g. "ack". Default: "ack".
+   */
+  routerShortCircuit: string;
 }
 
 /**
@@ -183,6 +191,7 @@ export function loadConfig(): Config {
     resultsPollIntervalSeconds: Number(process.env.AGENT_RESULTS_POLL_INTERVAL ?? "5"),
     postResults: bool(process.env.AGENT_POST_RESULTS, true),
     maxReplyChars: Number(process.env.AGENT_MAX_REPLY_CHARS ?? "12000"),
+    routerShortCircuit: (process.env.ROUTER_SHORT_CIRCUIT ?? "ack").trim(),
   };
 
   if (agentQueue.enabled) {

--- a/integrations/src/index.ts
+++ b/integrations/src/index.ts
@@ -34,8 +34,8 @@ async function main(): Promise<void> {
   const slack = config.slack.enabled ? new SlackConnector(config.slack, queue, awaitReply) : null;
 
   // Wire connectors into the queue so submit() can short-circuit acks directly.
-  if (queue && github && slack) {
-    queue.setConnectors({ slack, github });
+  if (queue && (github || slack)) {
+    queue.setConnectors({ slack: slack ?? undefined, github: github ?? undefined });
   }
 
   const shutdown = (signal: string) => {

--- a/integrations/src/index.ts
+++ b/integrations/src/index.ts
@@ -33,6 +33,11 @@ async function main(): Promise<void> {
   const github = config.github.enabled ? new GithubPoller(config.github, queue, awaitReply) : null;
   const slack = config.slack.enabled ? new SlackConnector(config.slack, queue, awaitReply) : null;
 
+  // Wire connectors into the queue so submit() can short-circuit acks directly.
+  if (queue && github && slack) {
+    queue.setConnectors({ slack, github });
+  }
+
   const shutdown = (signal: string) => {
     log.info(`Received ${signal}, shutting down…`);
     abort.abort();


### PR DESCRIPTION
## Sammendrag

Når første-linje-routeren klassifiserer et event som `ack`, leveres det direkte via connector-objektene (ack-reaksjon + working-reaksjon fjernet) uten å gå gjennom `inbox.jsonl` — proxy-agenten vekkes ikke unødvendig.

## Akseptansekriterier

- [x] En melding routeren klassifiserer som `ack` får ack-reaksjon (og working-reaksjonen fjernet) uten at proxy-agenten kjøres.
- [x] Events uten klassifisering (router av/feilet) køes som før — ingen endring i fallback-løypa.
- [x] Kortslutningen kan skrus av med tom `ROUTER_SHORT_CIRCUIT`-env-var.
- [x] Proxy-agentens prompt forklarer `classification` / `related_activities`.

## Endringer

| Fil | Hva |
|-----|-----|
| `integrations/src/config.ts` | Nytt felt `routerShortCircuit` i `AgentQueueConfig`, default `"ack"`, les fra `ROUTER_SHORT_CIRCUIT` |
| `integrations/src/agent/queue.ts` | `submit()` kortslutter ack via ny `deliverAckDirectly()`-metode; `setConnectors()` gir køen tilgang til connectorer |
| `integrations/src/index.ts` | `queue.setConnectors({slack, github})` etter at begge er konstruert |
| `integrations/.env.example` | Dokumenter `ROUTER_SHORT_CIRCUIT=ack` |
| `integrations/README.md` | Beskriv short-circuit-funksjonen i router-seksjonen |
| `agents/proxy-agent/docker/entrypoint.sh` | Legg til kontekst om `classification` og `related_activities` i prompten |

## Fallback-garantert

Kortslutningen er rent et optimeringssteg. Hvis routeren feiler, timeout eller produserer ugyldig output (allerede eksisterende oppførsel), går eventet gjennom normal kø — proxy-agentens egen klassifisering stiller likevel korrekte spørsmål.

Closes digdir/digdir-ai-agents#64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable router short-circuiting for acknowledgement events.
  * Matching events can now be delivered directly through supported connectors without waking the agent.
  * Added router context to help agents identify duplicate activities while retaining independent classification.

* **Documentation**
  * Documented the `ROUTER_SHORT_CIRCUIT` setting, including its default behavior and how to disable it.

* **Bug Fixes**
  * Added fallback handling so events return to the normal queue when direct delivery is unavailable or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->