### PR TITLE
self-update: docker compose down ved Q-trykk i watch-modus (#85)

### DIFF
--- a/scripts/self-update.ps1
+++ b/scripts/self-update.ps1
@@ -257,7 +257,13 @@ if ($WatchSeconds -gt 0) {
     try { Invoke-UpdatePass } catch { Write-Warning $_.Exception.Message }
     switch (Wait-WithHotkeys $WatchSeconds) {
       "reload" { try { Invoke-EnvReload } catch { Write-Warning $_.Exception.Message } }
-      "quit"   { Write-Step "Avslutter watch-modus."; $quit = $true }
+      "quit"   {
+        Write-Step "Stopper klyngen (docker compose down)..."
+        docker compose down 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Warning "docker compose down feilet — sjekk at Docker er tilgjengelig." }
+        Write-Step "Avslutter watch-modus."
+        $quit = $true
+      }
     }
   }
 } else {


### PR DESCRIPTION
@## Problem

Når `scripts/self-update.ps1` kjører i watch-modus og brukeren trykker **Q** for å avslutte, bryter scriptet ut av løkken — men containerne fortsetter å kjøres. Det etterlater en driftet klynge som må stoppes manuelt.

## Løsning

I Q-handtereren (watch-løkken) er det nå lagt til `docker compose down` før break:

```powershell
"quit"   {
  Write-Step "Stopper klyngen (docker compose down)..."
  docker compose down 2>$null
  if ($LASTEXITCODE -ne 0) { Write-Warning "docker compose down feilet — sjekk at Docker er tilgjengelig." }
  Write-Step "Avslutter watch-modus."
  $quit = $true
}
```

Feilhåndtering: hvis `docker compose down` feiler (f.eks. Docker utilgjengelig), skrives en advarsel, men break skjer uansett.

## Akseptansekriterier

- [x] Når Q trykkes i watch-modus, stoppes alle containere via `docker compose down` før scriptet avslutter
- [x] Det skrives en logglinje som bekrefter at klyngen stoppes
- [x] Hvis `docker compose down` feiler, skrives en advarsel, men scriptet avslutter likevel
- [x] Ingen andre deler av scriptet endres — kun Q-handtereren i watch-løkken

Closes digdir/digdir-ai-agents#85
@