### PR TITLE
llm-gateway: ett lokalt endepunkt for alle modellkall (fake nøkler ruter til backend)

### DIFF
--- a/agents/proxy-agent/.env.example
+++ b/agents/proxy-agent/.env.example
@@ -2,10 +2,12 @@
 
 # --- Lokalt LLM-endepunkt (default) ---
 # 127.0.0.1:8787 på hosten = host.docker.internal:8787 fra containeren.
-# Gateway-en trenger ingen API-nøkkel; "none" er en dummy-verdi Pi krever.
+# 8787 er llm-gatewayen (apps/llm-gateway): API-nøkkelen er en fake nøkkel
+# som identifiserer konsumenten i gatewayens routes.json, og modellnavnet
+# kan være et stabilt alias — gatewayen velger backend og ekte modell.
 LLM_BASE_URL=http://host.docker.internal:8787/v1
 LLM_MODEL_ID=aivar:gemma4
-LLM_API_KEY=none
+LLM_API_KEY=proxy-agent
 
 # --- Alternativt: sky-providere (brukes hvis du blanker LLM_BASE_URL) ---
 # ANTHROPIC_API_KEY=sk-ant-...

--- a/apps/llm-gateway/.env.example
+++ b/apps/llm-gateway/.env.example
@@ -1,0 +1,22 @@
+# Kopier til .env. .env er gitignorert — EKTE nøkler skal aldri inn i repoet.
+#
+# Upstreams navngis i routes.json og slås opp her etter konvensjonen
+# UPSTREAM_<NAVN>_URL / UPSTREAM_<NAVN>_KEY («-» i navnet blir «_»).
+# URL-en er basen som klientens path (f.eks. /v1/chat/completions) legges på
+# — har upstream et path-prefiks, ta det med her.
+
+# Hvor gatewayen lytter. 127.0.0.1 på hosten er nok: containere når den via
+# host.docker.internal. (docker-compose.yml overstyrer HOST inne i containeren
+# og publiserer porten kun på 127.0.0.1.)
+PORT=8787
+HOST=127.0.0.1
+
+# Aivar (OpenAI-kompatibelt endepunkt). Nøkkelen legges på som
+# "Authorization: Bearer ..." — konsumentenes fake nøkler går aldri videre.
+UPSTREAM_AIVAR_URL=
+UPSTREAM_AIVAR_KEY=
+
+# Lokal LM Studio (uten /v1 — klientens path har det allerede).
+# Fra container: docker-compose.yml overstyrer til host.docker.internal.
+UPSTREAM_LMSTUDIO_URL=http://127.0.0.1:1234
+UPSTREAM_LMSTUDIO_KEY=

--- a/apps/llm-gateway/.gitignore
+++ b/apps/llm-gateway/.gitignore
@@ -1,0 +1,2 @@
+.env
+routes.json

--- a/apps/llm-gateway/Dockerfile
+++ b/apps/llm-gateway/Dockerfile
@@ -1,0 +1,6 @@
+# Null avhengigheter — ingen npm install, bare Node-runtime og server.mjs.
+FROM node:24-alpine
+WORKDIR /app
+COPY package.json server.mjs ./
+USER node
+CMD ["node", "server.mjs"]

--- a/apps/llm-gateway/README.md
+++ b/apps/llm-gateway/README.md
@@ -1,0 +1,79 @@
+# llm-gateway — ett lokalt endepunkt for alle modellkall
+
+Liten null-avhengighets-gateway (Node ≥21) som samler pipelinens LLM-konfig på
+ETT sted. Alle konsumenter (integrations-routeren, proxy-agenten, …) peker på
+`http://…:8787/v1` med en **fake API-nøkkel** som identifiserer konsumenten;
+gatewayen velger backend per kall og legger på den ekte nøkkelen. Å bytte
+modell-backend er dermed én endring i `routes.json` — ingen agent-`.env`-filer
+eller container-restarts hos konsumentene.
+
+Arvtakeren til `llm-proxy-proxy` (én upstream, én modell-overstyring); samme
+passthrough-oppførsel (streaming/SSE pipes rett gjennom), men med ruting.
+
+## Ruting
+
+To trinn per forespørsel:
+
+1. **Fake nøkkel → konsument** (`Authorization: Bearer <nøkkel>` eller
+   `x-api-key`). Ukjent nøkkel avvises med 401 (fail closed).
+2. **Første regel som passer vinner**, ovenfra: valgfrie betingelser
+   `pathSuffix` (f.eks. `/embeddings`) og `whenModel` (eksakt match på
+   innkommende `model`-felt). En regel uten betingelser er default. Regelen
+   peker på en upstream og kan overstyre `model`-feltet — konsumentene kan
+   dermed bruke stabile alias (f.eks. `router-chat`) som aldri endres.
+
+`routes.json` (gitignorert, kopier fra `routes.example.json`) beskriver
+konsumenter og regler. Upstream-adresser og ekte nøkler ligger KUN i `.env`
+etter konvensjonen `UPSTREAM_<NAVN>_URL` / `UPSTREAM_<NAVN>_KEY`.
+
+Eksempel — routeren i integrations sender chat til Aivar og embeddings til
+lokal LM Studio over samme base-URL:
+
+```json
+"integrations-router": {
+  "keys": ["integrations-router"],
+  "rules": [
+    { "pathSuffix": "/embeddings", "upstream": "lmstudio", "model": "text-embedding-qwen3-embedding-4b" },
+    { "upstream": "aivar", "model": "aivar:gemma4" }
+  ]
+}
+```
+
+## Kjøring
+
+Anbefalt: container (overlever omstart, samme mønster som resten av klyngen):
+
+```powershell
+Copy-Item .env.example .env       # fyll inn upstream-URL-er og ekte nøkler
+Copy-Item routes.example.json routes.json
+docker compose up -d --build
+```
+
+Alternativt rett på hosten (Node ≥21): `npm start`.
+
+Helsesjekk uten auth: `GET /healthz` (kun navn — aldri nøkler).
+
+## Sikkerhet
+
+- Ekte nøkler finnes kun i `.env` (gitignorert) og legges på server-side; de
+  fake nøklene går aldri videre til upstream.
+- De fake nøklene er ruting-etiketter og en grov sperre — ikke en
+  sikkerhetsgrense. Gatewayen skal derfor kun være nåbar lokalt: den binder
+  `127.0.0.1` (containere når den via `host.docker.internal`).
+- Loggene inneholder konsument, path, modell og status — aldri nøkler eller
+  meldingsinnhold.
+
+## Verdt å vite
+
+- Klientens path legges rett på upstream-URL-en (som i `llm-proxy-proxy`), så
+  `/v1/models`, `/v1/embeddings` osv. fungerer. Har upstream et path-prefiks,
+  ta det med i `UPSTREAM_<NAVN>_URL`.
+- **Bytte av embedding-backend/-modell** endrer vektorrommet: routerens
+  persisterte aktivitetsindeks (i integrations-state) må da nullstilles, ellers
+  blir likhetssøkene stille dårlige.
+- Claude Code-agenter (jr-dev) snakker Anthropic-formatet (`/v1/messages`) —
+  det oversetter ikke gatewayen. De må mot en Anthropic-kompatibel backend
+  (LM Studio) eller en oversettende proxy (f.eks. LiteLLM) hvis de skal via
+  Aivar.
+- Endringer i `routes.json`/`.env` leses ved oppstart — restart gatewayen
+  (`docker compose restart`) for å ta dem i bruk.

--- a/apps/llm-gateway/docker-compose.yml
+++ b/apps/llm-gateway/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  llm-gateway:
+    build: .
+    image: digdir/llm-gateway:latest
+    env_file: .env
+    environment:
+      # Inne i containeren må serveren lytte på alle interfaces; eksponeringen
+      # styres av ports-publiseringen under (kun 127.0.0.1 på hosten).
+      HOST: 0.0.0.0
+      # Lokal LM Studio kjører på hosten — nås via host.docker.internal
+      # (overstyrer .env, som er skrevet for kjøring rett på hosten).
+      UPSTREAM_LMSTUDIO_URL: http://host.docker.internal:1234
+    extra_hosts:
+      # No-op på Docker Desktop, nødvendig på ren Linux
+      - host.docker.internal:host-gateway
+    ports:
+      - "127.0.0.1:8787:8787"
+    volumes:
+      - ./routes.json:/app/routes.json:ro
+    restart: ${RESTART_POLICY:-unless-stopped}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL

--- a/apps/llm-gateway/package.json
+++ b/apps/llm-gateway/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "llm-gateway",
+  "private": true,
+  "type": "module",
+  "description": "Lokal LLM-gateway: ruter OpenAI-kompatible kall på fake API-nøkkel (konsument) og path/modell (backend). Null avhengigheter.",
+  "engines": { "node": ">=21" },
+  "scripts": {
+    "start": "node server.mjs"
+  }
+}

--- a/apps/llm-gateway/routes.example.json
+++ b/apps/llm-gateway/routes.example.json
@@ -1,0 +1,17 @@
+{
+  "consumers": {
+    "integrations-router": {
+      "keys": ["integrations-router"],
+      "rules": [
+        { "pathSuffix": "/embeddings", "upstream": "lmstudio", "model": "text-embedding-qwen3-embedding-4b" },
+        { "upstream": "aivar", "model": "aivar:gemma4" }
+      ]
+    },
+    "proxy-agent": {
+      "keys": ["proxy-agent", "none"],
+      "rules": [
+        { "upstream": "aivar", "model": "aivar:gemma4" }
+      ]
+    }
+  }
+}

--- a/apps/llm-gateway/server.mjs
+++ b/apps/llm-gateway/server.mjs
@@ -1,0 +1,192 @@
+import http from 'node:http'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Last .env hvis den finnes (innebygd i Node 21+)
+try { process.loadEnvFile() } catch {}
+
+const PORT = Number(process.env.PORT ?? 8787)
+const HOST = process.env.HOST ?? '127.0.0.1'
+const ROUTES_FILE = process.env.ROUTES_FILE ?? fileURLToPath(new URL('./routes.json', import.meta.url))
+
+// ---------------------------------------------------------------------------
+// Konfig: routes.json beskriver konsumenter (fake API-nøkler) og regler.
+// Upstream-adresser og EKTE nøkler ligger kun i .env, etter konvensjonen
+// UPSTREAM_<NAVN>_URL / UPSTREAM_<NAVN>_KEY (navn med store bokstaver, «-» → «_»).
+// ---------------------------------------------------------------------------
+let config
+try {
+  config = JSON.parse(fs.readFileSync(ROUTES_FILE, 'utf8'))
+} catch (err) {
+  console.error(`Klarte ikke lese ${ROUTES_FILE}: ${err.message}`)
+  console.error('Kopier routes.example.json til routes.json og tilpass.')
+  process.exit(1)
+}
+
+const envName = (name) => name.toUpperCase().replaceAll('-', '_')
+
+// Slå opp alle upstreams reglene refererer, og feil ved oppstart (ikke ved
+// første kall) hvis en URL mangler i miljøet.
+const upstreams = new Map()
+for (const [consumerName, consumer] of Object.entries(config.consumers ?? {})) {
+  for (const rule of consumer.rules ?? []) {
+    const name = rule.upstream
+    if (!name) {
+      console.error(`Konsument "${consumerName}" har en regel uten "upstream".`)
+      process.exit(1)
+    }
+    if (upstreams.has(name)) continue
+    const url = (process.env[`UPSTREAM_${envName(name)}_URL`] ?? '').replace(/\/+$/, '')
+    const apiKey = process.env[`UPSTREAM_${envName(name)}_KEY`] ?? ''
+    if (!url) {
+      console.error(`UPSTREAM_${envName(name)}_URL mangler i .env (kreves av upstream "${name}").`)
+      process.exit(1)
+    }
+    upstreams.set(name, { name, url, apiKey })
+  }
+}
+
+// Fake nøkkel → konsument. Nøklene er ruting-etiketter og en grov sperre på
+// localhost — ikke en sikkerhetsgrense. Ukjent nøkkel avvises (fail closed).
+const byKey = new Map()
+for (const [name, consumer] of Object.entries(config.consumers ?? {})) {
+  for (const key of consumer.keys ?? []) {
+    if (byKey.has(key)) {
+      console.error(`Nøkkelen for "${name}" er allerede i bruk av "${byKey.get(key).name}".`)
+      process.exit(1)
+    }
+    byKey.set(key, { name, rules: consumer.rules ?? [] })
+  }
+}
+
+if (byKey.size === 0) {
+  console.error('routes.json har ingen konsumenter med nøkler — ingenting å rute.')
+  process.exit(1)
+}
+
+// Headere som ikke skal videresendes i noen retning
+const HOP_BY_HOP = new Set([
+  'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+  'te', 'trailer', 'transfer-encoding', 'upgrade', 'host',
+])
+
+function bearerToken(req) {
+  const auth = req.headers['authorization']
+  if (typeof auth === 'string' && auth.toLowerCase().startsWith('bearer ')) return auth.slice(7).trim()
+  const apiKey = req.headers['x-api-key']
+  if (typeof apiKey === 'string' && apiKey !== '') return apiKey.trim()
+  return ''
+}
+
+// Første regel som passer vinner: pathSuffix og whenModel er valgfrie
+// betingelser; en regel uten betingelser er konsumentens default.
+function pickRule(rules, pathname, model) {
+  for (const rule of rules) {
+    if (rule.pathSuffix && !pathname.endsWith(rule.pathSuffix)) continue
+    if (rule.whenModel && rule.whenModel !== model) continue
+    return rule
+  }
+  return undefined
+}
+
+function deny(res, status, message) {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({ error: { message, type: 'gateway_error' } }))
+}
+
+const server = http.createServer(async (req, res) => {
+  const pathname = (req.url ?? '/').split('?')[0]
+
+  // Helsesjekk uten auth — brukes av compose/konsoll. Aldri hemmeligheter her.
+  if (req.method === 'GET' && pathname === '/healthz') {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({
+      ok: true,
+      consumers: [...new Set([...byKey.values()].map((c) => c.name))],
+      upstreams: [...upstreams.keys()],
+    }))
+    return
+  }
+
+  try {
+    const consumer = byKey.get(bearerToken(req))
+    if (!consumer) {
+      console.warn(`${req.method} ${pathname} -> 401 (ukjent nøkkel)`)
+      deny(res, 401, 'Ukjent API-nøkkel. Gatewayen ruter kun kjente konsumenter (se routes.json).')
+      return
+    }
+
+    const chunks = []
+    for await (const chunk of req) chunks.push(chunk)
+    let body = chunks.length ? Buffer.concat(chunks) : undefined
+
+    // Plukk ut model-feltet fra JSON-bodyer, både for regelvalg og overstyring
+    let json
+    const contentType = req.headers['content-type'] ?? ''
+    if (body && contentType.includes('application/json')) {
+      try { json = JSON.parse(body.toString('utf8')) } catch { /* ikke gyldig JSON – urørt videre */ }
+    }
+    const incomingModel = json && typeof json === 'object' ? json.model : undefined
+
+    const rule = pickRule(consumer.rules, pathname, incomingModel)
+    if (!rule) {
+      console.warn(`${consumer.name}: ${req.method} ${pathname} (model: ${incomingModel ?? '-'}) -> 404 (ingen regel)`)
+      deny(res, 404, `Ingen regel for ${pathname} hos konsumenten "${consumer.name}".`)
+      return
+    }
+    const upstream = upstreams.get(rule.upstream)
+
+    let modelNote = ''
+    if (rule.model && json && typeof json === 'object' && 'model' in json) {
+      modelNote = ` (model: ${json.model} -> ${rule.model})`
+      json.model = rule.model
+      body = Buffer.from(JSON.stringify(json))
+    }
+
+    const headers = {}
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (!HOP_BY_HOP.has(key) && key !== 'content-length' && key !== 'x-api-key') headers[key] = value
+    }
+    // Den fake nøkkelen skal aldri videre; upstream får sin ekte nøkkel — eller
+    // ingen auth i det hele tatt (lokale servere som LM Studio).
+    if (upstream.apiKey) headers['authorization'] = `Bearer ${upstream.apiKey}`
+    else delete headers['authorization']
+
+    const started = Date.now()
+    const upstreamRes = await fetch(upstream.url + req.url, {
+      method: req.method,
+      headers,
+      body,
+    })
+
+    // fetch dekomprimerer responsen, så content-encoding/length stemmer ikke lenger
+    const resHeaders = {}
+    for (const [key, value] of upstreamRes.headers) {
+      if (!HOP_BY_HOP.has(key) && key !== 'content-encoding' && key !== 'content-length') {
+        resHeaders[key] = value
+      }
+    }
+    res.writeHead(upstreamRes.status, resHeaders)
+
+    if (upstreamRes.body) {
+      for await (const chunk of upstreamRes.body) res.write(chunk)
+    }
+    res.end()
+
+    console.log(`${consumer.name}: ${req.method} ${pathname} -> ${upstream.name} ${upstreamRes.status}${modelNote} (${Date.now() - started}ms)`)
+  } catch (err) {
+    console.error(`${req.method} ${pathname} -> feil:`, err.cause ?? err)
+    if (!res.headersSent) {
+      res.writeHead(502, { 'content-type': 'application/json' })
+    }
+    res.end(JSON.stringify({ error: { message: `Gateway-feil: ${err.message}`, type: 'gateway_error' } }))
+  }
+})
+
+server.listen(PORT, HOST, () => {
+  console.log(`llm-gateway lytter på http://${HOST}:${PORT} (ruter: ${ROUTES_FILE})`)
+  for (const [name, consumer] of Object.entries(config.consumers ?? {})) {
+    const targets = [...new Set((consumer.rules ?? []).map((r) => r.upstream))].join(', ')
+    console.log(`  - ${name} -> ${targets}`)
+  }
+})

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,19 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-27** — `apps/llm-gateway/`: lokal LLM-gateway som samler all
+  modell-konfig på ett sted. Konsumenter (integrations-routeren,
+  proxy-agenten) peker på ett endepunkt (`:8787/v1`) med en fake API-nøkkel
+  som identifiserer konsumenten; gatewayen ruter per regel (path/modell) til
+  riktig backend og legger på den ekte nøkkelen — routerens chat og
+  embeddings kan dermed gå til hver sin backend over samme base-URL
+  (routeren har fortsatt kun ett `ROUTER_BASE_URL`). Konsumentene bruker
+  stabile modell-alias; backend-bytte er én endring i gatewayens
+  `routes.json`. Null avhengigheter (Node ≥21), container-kjøring med
+  publisering kun på `127.0.0.1`. Arvtakeren til den frittstående
+  `llm-proxy-proxy`-en. Foranledning: fjern LM Studio-backend utilgjengelig
+  — chat måtte via Aivar mens embeddings kjøres på lokal LM Studio.
+
 - **2026-07-24** — Junior-agenten containerisert (issue #90): engangs-
   container per event i stedet for interaktiv CLI på hosten. Runner
   (`scripts/jr-runner.ps1`, erstatter `junior-agent.ps1`) poller innboksen

--- a/integrations/.env.example
+++ b/integrations/.env.example
@@ -144,30 +144,39 @@ AGENT_DELEGATION_DEBRIEF=true
 # ---------------------------------------------------------------------------
 # First-line router (optional — classification + activity matching)
 # ---------------------------------------------------------------------------
-# OpenAI-compatible endpoint for a small, fast local model (e.g. LM Studio).
-# Incoming events are annotated with a classification and references to
-# similar open activities BEFORE they are appended to the agent's inbox. The
-# router only annotates — it never drops or reroutes events, and any error or
-# timeout falls back to the unannotated event.
+# OpenAI-compatible endpoint for a small, fast model. Incoming events are
+# annotated with a classification and references to similar open activities
+# BEFORE they are appended to the agent's inbox. The router only annotates —
+# it never drops or reroutes events, and any error or timeout falls back to
+# the unannotated event.
 # Empty = router off; behaviour is exactly as before (backward compatible).
-# NOTE (Docker): the container reaches the host's LM Studio via
+#
+# RECOMMENDED: point this at the local llm-gateway (apps/llm-gateway) instead
+# of a model server directly. The gateway routes chat and embeddings to
+# different backends per rule, so ROUTER_MODEL/ROUTER_EMBEDDING_MODEL can be
+# stable aliases — switching backends is then a gateway-config change only.
+# NOTE (Docker): the container reaches the host's gateway via
 # host.docker.internal (on plain Linux add an extra_hosts:
 # "host.docker.internal:host-gateway" mapping in docker-compose.yml).
 ROUTER_BASE_URL=
-#ROUTER_BASE_URL=http://host.docker.internal:1234/v1
+#ROUTER_BASE_URL=http://host.docker.internal:8787/v1
 
 # Chat model used to classify events (action/feedback/ack/delegate).
+# Via the gateway this is a stable alias the gateway rewrites per rule.
 # Empty = no classification annotation.
-ROUTER_MODEL=gemma-4-12b-it-mlx@8bit
+ROUTER_MODEL=router-chat
 
-# Sent as a Bearer token. Local servers like LM Studio accept any value.
-ROUTER_API_KEY=lmstudio
+# Sent as a Bearer token. Via the gateway this identifies the consumer
+# (routes.json); local servers like LM Studio accept any value.
+ROUTER_API_KEY=integrations-router
 
 # Embedding model for matching events against open activities (Slack threads,
 # GitHub issues) with cosine similarity. The index is persisted in
 # AGENT_STATE_DIR (the integrations-state volume in Docker), so it survives
 # restarts. Empty = no activity matching.
-ROUTER_EMBEDDING_MODEL=text-embedding-qwen3-embedding-4b
+# Via the gateway this too is a stable alias. NOTE: changing the underlying
+# embedding model changes the vector space — reset the persisted index.
+ROUTER_EMBEDDING_MODEL=router-embedding
 
 # Per-call timeout in milliseconds. On timeout the event is queued unannotated.
 ROUTER_TIMEOUT_MS=10000


### PR DESCRIPTION
## Hva

Ny app `apps/llm-gateway/`: en lokal null-avhengighets-gateway (Node ≥21) som samler pipelinens modell-konfig på ett sted. Alle konsumenter peker på ett endepunkt (`127.0.0.1:8787/v1`) med en **fake API-nøkkel** som identifiserer konsumenten; gatewayen velger backend per regel (path-suffiks/modell) og legger på den ekte nøkkelen server-side. Arvtakeren til den frittstående `llm-proxy-proxy`-en (samme passthrough/streaming-oppførsel, men med ruting).

## Hvorfor

Fjern LM Studio-backend er utilgjengelig: chat må via Aivar, mens embeddings kjøres på lokal LM Studio. Routeren i integrations har kun ett `ROUTER_BASE_URL` for begge kall-typene — i stedet for å innføre enda en env-variabel i integrations løses splitten i gatewayen, der `/embeddings` og `/chat/completions` rutes hver sin vei over samme base-URL. Samtidig blir konfig-floka mindre: konsumentene bruker stabile modell-alias (`router-chat`, `router-embedding`), og backend-bytte er heretter én endring i gatewayens `routes.json` — ingen agent-`.env`-filer eller container-restarts hos konsumentene.

## Endringer

- `apps/llm-gateway/`: server, `routes.example.json`, `.env.example`, Dockerfile + compose (publisering kun på `127.0.0.1`, `no-new-privileges`, `cap_drop: ALL`), README.
- `integrations/.env.example`: router-seksjonen anbefaler gatewayen og alias-navn (kun docs/eksempel — ingen kodeendring i integrations).
- `agents/proxy-agent/.env.example`: peker på gatewayen med konsument-nøkkel `proxy-agent` (legacy-nøkkelen `none` støttes fortsatt i routes-eksemplet).
- `doc/log.md`: loggoppføring.

## Sikkerhet

- Ekte nøkler kun i gitignorert `.env` på hosten; fake nøkler går aldri videre til upstream, og `x-api-key` strippes utover.
- Ukjent nøkkel → 401 (fail closed). Logger inneholder konsument/path/modell/status — aldri nøkler eller meldingsinnhold.
- Binder kun `127.0.0.1` på hosten; containere når den via `host.docker.internal`.

## Verifisert

Kjørt lokalt mot ekte backends: `/healthz`; embeddings-alias → lokal LM Studio (qwen3, 2560-dim); chat-alias med `response_format: json_schema` (routerens klassifiseringskall) → Aivar OK; legacy-nøkkel `none` → Aivar OK; ukjent nøkkel → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
