### PR TITLE
Rot-compose: inkluder llm-gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,4 @@ name: digdir-ai-agents
 include:
   - integrations/docker-compose.yml
   - agents/proxy-agent/docker-compose.yml
+  - apps/llm-gateway/docker-compose.yml


### PR DESCRIPTION
Énlinjer: llm-gateway (#100) inn i rot-composens `include`, slik toppkommentaren i fila foreskriver — «drar opp hele pipelinen» skal nå også omfatte gatewayen, som både integrations-routeren og proxy-agenten avhenger av.

Forutsetning (allerede på plass i deploy-klonen): `apps/llm-gateway/.env` og `routes.json` må finnes før `docker compose up` fra rota — ellers feiler oppstarten av tjenesten.

**Obs ved evt. kjøring fra rota:** klyngen kjører i dag som per-katalog-prosjekter (`integrations`, `proxy-agent`, `llm-gateway`), ikke under rot-prosjektet `digdir-ai-agents`. `docker compose up` fra rota vil derfor lage *nye* containere ved siden av de kjørende (og gatewayen vil kollidere på port 8787). Skal rota tas i bruk som inngang (slik `scripts/self-update.ps1` forutsetter), må per-katalog-prosjektene tas ned én gang først — egen opsrunde, ikke del av denne PR-en.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
