### PR TITLE
llm-gateway: subscription-OAuth for Claude Code-agenter (jr-dev tilbake på lufta)

### DIFF
--- a/agents/local-cc-jr-developer/.env.example
+++ b/agents/local-cc-jr-developer/.env.example
@@ -12,11 +12,19 @@ GH_TOKEN=
 GIT_USER_NAME=
 GIT_USER_EMAIL=
 
-# --- LLM: LM Studio på hosten via Anthropic-kompatibelt /v1/messages-API ---
-# 127.0.0.1:1234 på hosten = host.docker.internal:1234 fra containeren.
-ANTHROPIC_BASE_URL=http://host.docker.internal:1234
-ANTHROPIC_AUTH_TOKEN=lmstudio
-ANTHROPIC_MODEL=ornith-1.0-35b-nvfp4-mtp
-# Uten denne går Claude Codes bakgrunnskall mot et claude-*-modellnavn som
-# ikke finnes i LM Studio; pek dem på samme lokale modell.
-ANTHROPIC_SMALL_FAST_MODEL=ornith-1.0-35b-nvfp4-mtp
+# --- LLM-backend (velg én) ---
+#
+# Variant A: Anthropic via llm-gatewayen med subscription-OAuth (se
+# apps/llm-gateway/README.md). AUTH_TOKEN er konsument-nøkkelen i gatewayens
+# routes.json — det ekte OAuth-tokenet bor kun i gatewayens .env og er aldri
+# inne i denne containeren. Ingen modell-overstyring: ekte modellnavn brukes.
+ANTHROPIC_BASE_URL=http://host.docker.internal:8787
+ANTHROPIC_AUTH_TOKEN=jr-developer
+#
+# Variant B: LM Studio på hosten via Anthropic-kompatibelt /v1/messages-API
+# (lokal modell). Da må også bakgrunnskallene pekes på samme modell — uten
+# ANTHROPIC_SMALL_FAST_MODEL går de mot et claude-*-navn som ikke finnes der.
+#ANTHROPIC_BASE_URL=http://host.docker.internal:1234
+#ANTHROPIC_AUTH_TOKEN=lmstudio
+#ANTHROPIC_MODEL=ornith-1.0-35b-nvfp4-mtp
+#ANTHROPIC_SMALL_FAST_MODEL=ornith-1.0-35b-nvfp4-mtp

--- a/apps/llm-gateway/.env.example
+++ b/apps/llm-gateway/.env.example
@@ -20,3 +20,9 @@ UPSTREAM_AIVAR_KEY=
 # Fra container: docker-compose.yml overstyrer til host.docker.internal.
 UPSTREAM_LMSTUDIO_URL=http://127.0.0.1:1234
 UPSTREAM_LMSTUDIO_KEY=
+
+# Anthropic for Claude Code-agenter (jr-dev): nøkkelen er et langlivet
+# subscription-OAuth-token fra `claude setup-token` (sk-ant-oat...).
+# Tokenet bor KUN her — aldri i agent-containernes env (se README).
+UPSTREAM_ANTHROPIC_URL=https://api.anthropic.com
+UPSTREAM_ANTHROPIC_KEY=

--- a/apps/llm-gateway/README.md
+++ b/apps/llm-gateway/README.md
@@ -53,6 +53,29 @@ Alternativt rett på hosten (Node ≥21): `npm start`.
 
 Helsesjekk uten auth: `GET /healthz` (kun navn — aldri nøkler).
 
+## Claude Code-agenter med subscription-OAuth (jr-dev)
+
+Claude Code snakker Anthropic-formatet (`/v1/messages`), som gatewayen sender
+urørt videre — så en Claude Code-agent i container kan bruke gatewayen som
+base-URL, med et **subscription-OAuth-token som aldri er inne i containeren**
+(samme «credential non-possession»-idé som nvt-agents mediated mode, i
+miniatyr — uten refresh-maskineri, siden `setup-token` er langlivet):
+
+1. Kjør `claude setup-token` i et pålogget miljø (krever abonnement) og legg
+   tokenet i `UPSTREAM_ANTHROPIC_KEY` i gatewayens `.env`.
+2. Gi agenten en konsument-regel mot `anthropic` med
+   `"appendHeaders": { "anthropic-beta": "oauth-2025-04-20" }` — OAuth-tokens
+   krever denne beta-flaggingen, og klienten vet ikke selv at den kjører OAuth.
+   `appendHeaders` *fletter* verdien inn i klientens eksisterende beta-liste
+   (erstatter aldri — klienten eier sin egen feature-liste).
+3. Agentens miljø: `ANTHROPIC_BASE_URL=http://host.docker.internal:8787` og
+   `ANTHROPIC_AUTH_TOKEN=<konsument-nøkkelen>`. Ingen modell-overstyring —
+   ekte modellnavn går rett gjennom.
+
+Trafikken er ekte Claude Code-trafikk (kun auth-headeren byttes), så
+Anthropics krav om Claude Code-systemprompt for subscription-tokens er
+oppfylt av seg selv.
+
 ## Sikkerhet
 
 - Ekte nøkler finnes kun i `.env` (gitignorert) og legges på server-side; de
@@ -71,9 +94,10 @@ Helsesjekk uten auth: `GET /healthz` (kun navn — aldri nøkler).
 - **Bytte av embedding-backend/-modell** endrer vektorrommet: routerens
   persisterte aktivitetsindeks (i integrations-state) må da nullstilles, ellers
   blir likhetssøkene stille dårlige.
-- Claude Code-agenter (jr-dev) snakker Anthropic-formatet (`/v1/messages`) —
-  det oversetter ikke gatewayen. De må mot en Anthropic-kompatibel backend
-  (LM Studio) eller en oversettende proxy (f.eks. LiteLLM) hvis de skal via
-  Aivar.
+- Gatewayen *oversetter ikke* mellom API-formater: Anthropic-formatet
+  (`/v1/messages`) sendes urørt videre og krever en Anthropic-kompatibel
+  upstream (api.anthropic.com — se OAuth-avsnittet — eller LM Studio).
+  Skal Claude Code-agenter via et rent OpenAI-endepunkt (Aivar), trengs en
+  oversettende proxy (f.eks. LiteLLM).
 - Endringer i `routes.json`/`.env` leses ved oppstart — restart gatewayen
   (`docker compose restart`) for å ta dem i bruk.

--- a/apps/llm-gateway/routes.example.json
+++ b/apps/llm-gateway/routes.example.json
@@ -12,6 +12,12 @@
       "rules": [
         { "upstream": "aivar", "model": "aivar:gemma4" }
       ]
+    },
+    "jr-developer": {
+      "keys": ["jr-developer"],
+      "rules": [
+        { "upstream": "anthropic", "appendHeaders": { "anthropic-beta": "oauth-2025-04-20" } }
+      ]
     }
   }
 }

--- a/apps/llm-gateway/server.mjs
+++ b/apps/llm-gateway/server.mjs
@@ -152,6 +152,18 @@ const server = http.createServer(async (req, res) => {
     if (upstream.apiKey) headers['authorization'] = `Bearer ${upstream.apiKey}`
     else delete headers['authorization']
 
+    // appendHeaders (f.eks. anthropic-beta for subscription-OAuth): flettes inn
+    // i klientens eksisterende verdi i stedet for å erstatte den — klienten
+    // eier sin egen feature-liste. Kun for ikke-hemmelige verdier.
+    for (const [name, value] of Object.entries(rule.appendHeaders ?? {})) {
+      const key = name.toLowerCase()
+      const existing = headers[key]
+      if (existing === undefined || existing === '') headers[key] = value
+      else if (!String(existing).split(',').map((s) => s.trim()).includes(value)) {
+        headers[key] = `${existing},${value}`
+      }
+    }
+
     const started = Date.now()
     const upstreamRes = await fetch(upstream.url + req.url, {
       method: req.method,

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,18 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-27** — llm-gateway: Claude Code-agenter (jr-dev) kan kjøre mot
+  Anthropic med subscription-OAuth uten at tokenet er inne i containeren —
+  credential-non-possession-mønsteret fra nvt-agents mediated mode i
+  miniatyr (jf. `doc/plans/nvt-agent-integrasjon.md`). Langlivet token fra
+  `claude setup-token` bor kun i gatewayens `.env` (upstream `anthropic`);
+  ny generisk `appendHeaders` per regel fletter `anthropic-beta:
+  oauth-2025-04-20` inn i klientens beta-liste (appender, erstatter aldri —
+  lærdom fra nvt). Agentens env: base-URL mot gatewayen + konsument-nøkkel.
+  Foranledning: fjern LM Studio fortsatt utilgjengelig og Aivar mangler
+  Anthropic-format — dette gir jr-dev backend igjen, med uendret
+  GitHub-identitet og sandbox.
+
 - **2026-07-27** — `apps/llm-gateway/`: lokal LLM-gateway som samler all
   modell-konfig på ett sted. Konsumenter (integrations-routeren,
   proxy-agenten) peker på ett endepunkt (`:8787/v1`) med en fake API-nøkkel


### PR DESCRIPTION
## Hva

jr-dev får LLM-backend igjen: Claude Code i containeren går via llm-gatewayen til api.anthropic.com med et **subscription-OAuth-token som aldri er inne i agent-containeren** — credential-non-possession-mønsteret fra nvt-agents mediated mode (jf. `docs/claude-auth.md` i nvt-repoet), i miniatyr via gatewayen vi allerede har. Langlivet token fra `claude setup-token` gjør at vi slipper refresh-maskineriet i denne omgangen.

## Endringer

- `apps/llm-gateway/server.mjs`: ny valgfri `appendHeaders` per regel — verdien **flettes** inn i klientens eksisterende header (komma-liste, dedupliseres), erstatter aldri. Trengs fordi OAuth-tokens krever `anthropic-beta: oauth-2025-04-20`, mens Claude Code (som ikke vet at den kjører OAuth) eier sin egen beta-liste. Append-ikke-erstatt er en lærdom hentet rett fra nvt (`fix: preserve Claude feature beta headers`).
- `routes.example.json`: ny konsument `jr-developer` → upstream `anthropic` med beta-fletting.
- `.env.example`: `UPSTREAM_ANTHROPIC_URL/_KEY` (tokenet bor kun her).
- `README.md`: oppskrift for Claude Code-agenter med subscription-OAuth + presisert at gatewayen aldri oversetter mellom API-formater.
- `agents/local-cc-jr-developer/.env.example`: variant A (gateway/OAuth, ingen modell-overstyring) og variant B (LM Studio) — kun eksempel-fil.
- `doc/log.md`: loggoppføring.

## Sikkerhet

- OAuth-tokenet (Oles abonnement) er aldri i containeren som behandler upålitelige events — containeren har kun en fake konsument-nøkkel som bare virker mot gatewayen på localhost.
- Trafikken er ekte Claude Code-trafikk; kun auth-headeren byttes server-side. GitHub-identitet (jr-ens eget PAT) og container-sandbox er uendret.
- `appendHeaders` er dokumentert kun for ikke-hemmelige verdier; hemmeligheter går fortsatt kun i replace-header (`authorization`).

## Verifisert

Mot lokal echo-upstream: header settes når fraværende, flettes med eksisterende beta-verdier, dedupliseres når allerede til stede; ekte nøkkel injiseres og fake nøkkel/`x-api-key` strippes. Ende-til-ende mot api.anthropic.com gjenstår til `claude setup-token`-tokenet er lagt i gatewayens `.env` (Oles manuelle steg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
