### PR TITLE
Fiks: runner-tasks skal overleve batteridrift

### DIFF
--- a/scripts/install-agent-tasks.ps1
+++ b/scripts/install-agent-tasks.ps1
@@ -70,7 +70,11 @@ foreach ($t in $tasks) {
     -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -Command `"$command`"" `
     -WorkingDirectory $repoRoot
   $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+  # Batteri-flaggene er ikke pynt: Task Schedulers default er å STOPPE
+  # kjørende tasks når maskinen går på batteri — på en laptop dør runnerne
+  # stille i det øyeblikket laderen ryker (observert 2026-07-27).
   $settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
     -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 2) `
     -ExecutionTimeLimit (New-TimeSpan -Days 0) `
     -MultipleInstances IgnoreNew `


### PR DESCRIPTION
Task Schedulers default er å stoppe kjørende tasks når maskinen går på batteri — begge runner-taskene døde stille da laderen røk i dag (jr og sr sto i Ready uten feil i loggene; oppdaget fordi et injisert event ble liggende ubehandlet). Fiks: \-AllowStartIfOnBatteries -DontStopIfGoingOnBatteries\ i \install-agent-tasks.ps1\. De kjørende taskene er allerede oppdatert manuelt med samme innstillinger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)