### PR TITLE
Proxy-agent: push-sikkerhetsnett for kunnskapsbasen etter hver kjøring

### DIFF
--- a/agents/proxy-agent/docker/entrypoint.sh
+++ b/agents/proxy-agent/docker/entrypoint.sh
@@ -84,6 +84,25 @@ sync_knowledge() {
   fi
 }
 
+# Sikkerhetsnett etter hver kjøring: sync_knowledge pusher bare ved oppstart,
+# og containeren kjører lenge — commits en kjøring etterlater upushet ville
+# ellers blitt liggende lokalt på ubestemt tid. Et skittent arbeidstre betyr
+# at kjøringen hoppet over commit-steget i skillen sin; det kan ikke
+# repareres trygt herfra (vi vet ikke hva som hører sammen), så det varsles.
+knowledge_push_pending() {
+  [[ -n "$KB_GH_TOKEN" && -d "$KNOWLEDGE_DIR/.git" ]] || return 0
+  if [[ -n "$(git -C "$KNOWLEDGE_DIR" status --porcelain 2>/dev/null)" ]]; then
+    log "WARN: kunnskapsbasen har ukommitterte endringer — kjøringen hoppet over commit-steget"
+  fi
+  if [[ -n "$(git -C "$KNOWLEDGE_DIR" log --branches --not --remotes --oneline 2>/dev/null | head -n 1)" ]]; then
+    if git -C "$KNOWLEDGE_DIR" push --quiet 2>/dev/null; then
+      log "Kunnskapsbase: pushet commits som lå igjen lokalt"
+    else
+      log "WARN: Kunnskapsbase: push feilet — nytt forsøk etter neste kjøring"
+    fi
+  fi
+}
+
 # Skills bakt inn i imaget (se Dockerfile). Lastes eksplisitt med --skill
 # siden ~/.pi ligger på et volum som ville skygget image-innhold.
 SKILLS_DIR="${SKILLS_DIR:-/opt/pi-skills}"
@@ -187,6 +206,7 @@ run_synthesis() {
   rc=$?
   set -e
   log "Kunnskapssyntese: ferdig (exit $rc)"
+  knowledge_push_pending
 }
 
 # Kort hint om kunnskapsbasen, kun når den faktisk er tilgjengelig.
@@ -293,6 +313,7 @@ process_event() {
        + (if $extraction_failed == true then {extraction_failed: true} else {} end)' \
     >>"$RESULT_FILE"
   log "Event $id ferdig (exit $exit_code, intent=${intent:-?}, logg: $log_file)"
+  knowledge_push_pending
 }
 
 watch_loop() {


### PR DESCRIPTION
## Bakgrunn

Slack-oppgaven «les docs.altinn.studio» (27.07) etterlot kunnskapsarbeidet **ukommittert** i `/knowledge` — ingenting nådde knowledge-repoet. Samme dag hadde også en avbrutt syntese-kjøring (0-byte logg) etterlatt to `process/`-sider ukommittert. Rotårsaker:

1. Agenten hoppet over commit/push-steget i skillen (ingenting håndhever det).
2. `sync_knowledge()` — det eneste som re-pusher — kjører kun ved **container-oppstart**, og watch-containeren kjører i dagevis.
3. Ukommitterte arbeidstre-endringer fanges aldri opp av noe, og kan i tillegg få oppstartens `git pull --ff-only` til å feile stille.

(De konkrete filene fra 27.07 er allerede berget manuelt — commit `d39a93c` + `2e66b8f` i knowledge-base-dd.)

## Endring

Ny `knowledge_push_pending()` i proxy-agentens entrypoint, kalt etter **hvert event** (`process_event`) og etter **hver syntese** (`run_synthesis`):

- Upushede lokale commits prøves pushet på nytt (nettverksglipp, glemt push).
- Skittent arbeidstre logges som `WARN: … kjøringen hoppet over commit-steget` — auto-commit gjøres bevisst *ikke* (entrypointet kan ikke vite hva som hører sammen, og risikerer å feie med seg ting som ikke skal ut).
- No-op når kunnskapsbasen er inaktiv (tom `KB_GH_TOKEN`) — som før.

`bash -n` ok. Ingen endring i event-/resultatkontrakten.

## Test

Etter merge + self-update: gjør en liten commit i `/knowledge` fra containeren uten push, trigg et vilkårlig event, og se `Kunnskapsbase: pushet commits som lå igjen lokalt` i containerloggen.

Refs #104 (samme familie: kjøringer som ikke fullfører protokollen sin skal ikke feile stille)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
