### PR TITLE
docs: M0-funn fra nvt-sandkassebeviset (Refs #96)

### DIFF
--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,14 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-30** — nvt M0 (issue #96) gjennomført: sandkasse-bevis på WSL2
+  med hele kjeden prompt → levende claude-sesjon (Sonnet via llm-gatewayen)
+  → branch/commit/push/PR av bot-identiteten med broker-utstedt token;
+  oppfølgings-prompt fortsatte samme samtale. Sju praktiske funn (non-root,
+  stier, volumer, commit-identitet, onboarding, host-oppslag) er ført inn i
+  [nvt-agent-integrasjon.md](plans/nvt-agent-integrasjon.md) under
+  «M0-funn». M1-kjernen ligger klar i PR #110.
+
 - **2026-07-28** — PR-prosess (issue #54) sluttført: plattformoppsettet fra
   [pr-prosess.md](pr-prosess.md) er nå aktivt i produksjon. Branch
   protection (required approvals 0 + Require review from Code Owners +

--- a/doc/plans/nvt-agent-integrasjon.md
+++ b/doc/plans/nvt-agent-integrasjon.md
@@ -274,6 +274,47 @@ PAT på bot-kontoen) gjenbrukes som broker-provider her — men fat-dev bør få
 sitt *eget* token, ikke dele jr-ens, så de kan skilles i audit og
 revokeres hver for seg.
 
+## M0-funn (gjennomført 2026-07-30, WSL2 Ubuntu-24.04)
+
+Hele kjeden er bevist: prompt via `agentdctl` → claude (Sonnet via
+llm-gatewayen) i levende tmux-sesjon → branch + commit + push + PR i
+testrepoet (`nvt-m0-test`) opprettet av bot-identiteten med broker-utstedt
+token — og en oppfølgings-prompt i samme sesjon fortsatte samme samtale
+(PR-en fikk commit nr. 2 uten re-forklaring av kontekst). code-server
+svarer bak Traefik. Verifisert: `FATDEV_GH_TOKEN` finnes ikke i
+agentcontainerens env; i direct mode/file-bundle ligger en liten
+credential-config (`~/.nvt-agent/git-credentials/config.yaml`, ~200 bytes)
+som `git-credential-nvt`-helperen og `gh-auth`-wrapperen bruker —
+tokenverdien selv bor kun i `.broker/env` på hosten. Modell-allowlisten i
+gatewayen håndhever fail-closed (verifisert med avvist modell).
+
+Feller M1-implementasjonen må kjenne (alle truffet i praksis):
+
+1. **claude nekter `--dangerously-skip-permissions` som root** → agenten
+   MÅ kjøres i nvt-ens non-root-modus (`agent-init --user non-root`).
+   Symptom ellers: tmux-sesjonen dør innen 5 s, tre forsøk, container exit.
+2. **nvt-sjekkouten kan ikke ligge under `/root`** på verten: workspace
+   bind-mountes på samme absolutte sti i containeren, og uid 1000 kommer
+   ikke gjennom `/root` (700). Bruk f.eks. `/srv/nvt-agent`. (Samme krav
+   som bridge-planens «host-gyldige stier».)
+3. **Bytte root→non-root på eksisterende agent krever at named-volumene
+   slettes** (`agent-m0_agent-home`, `agent-m0_docker-data`) — de beholder
+   root-eierskap og gir `Permission denied` ved bootstrap.
+4. **`static_token`-provideren støtter ikke `identity.mode: provider`** —
+   commit-identitet må settes eksplisitt i `agent.yaml`
+   (`mode: explicit` + navn/e-post for bot-kontoen).
+5. **claude-onboardingen spiser første prompt**: velkomstskjerm +
+   trust-dialog må gjennom (to Enter i tmux) før agentd-prompts når
+   claude; preseed-`settings.json` dekker det ikke i dag. Bridgen (M1) må
+   enten preseede onboarding-state eller vente på klar-prompt før første
+   injeksjon.
+6. **Gatewayen nås fra agentcontaineren** via `host.docker.internal:8787`
+   (200 OK) tross `network_mode: service:docker` — det åpne spørsmålet fra
+   planen er avklart, ingen gateway-IP-triksing nødvendig.
+7. Diverse: `gh` finnes i runtime-imaget og `gh-auth` (plugin-eksportert
+   wrapper) gir PR-opprettelse uten token i miljøet; Windows-siden må ikke
+   røres — alt kjøres fra WSL2-distroen med filene på Linux-filsystemet.
+
 ## Milepæler
 
 **M0 — Sandkasse-bevis (manuelt, ingen repo-endringer).** Bygg nvt fra


### PR DESCRIPTION
Refs #96.

M0-sandkassebeviset er gjennomført (2026-07-30, WSL2 Ubuntu-24.04) og alle akseptansekriteriene i issuet er verifisert:

- ✅ PR i testrepoet opprettet av bot-kontoen (nvt-m0-test PR #1, `gh-auth` med broker-token); `FATDEV_GH_TOKEN` finnes ikke i containerens env — kun en ~200 B credential-config for helperen (file-bundle, notert for M4/mediated).
- ✅ Claude Code kjører mot llm-gatewayen fra containeren (`host.docker.internal:8787`, egen `fat-developer`-konsument, fail-closed allowlist verifisert). Eksakt env dokumentert i plan-notatet.
- ✅ Oppfølgings-prompt i samme sesjon fortsatte samme samtale (commit 2 på samme PR uten re-forklart kontekst).
- ✅ code-server svarer bak Traefik (302 → login).
- ✅ Denne PR-en er funn-notatet ført tilbake i planen: sju praktiske feller (non-root-krav, sti-/volum-feller, eksplisitt commit-identitet for `static_token`, onboarding-fella som spiser første prompt, avklart host-oppslag).

Doc-only (`doc/`), utenfor CODEOWNERS-stiene — setter `auto-merge`-label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
