### PR TITLE
nvt M1: kalibrer den ekte adapteren mot M0-funnene (Refs #97)

### DIFF
--- a/agents/nvt-fat-developer/.env.example
+++ b/agents/nvt-fat-developer/.env.example
@@ -9,15 +9,19 @@
 # Bridgens egen config ligger i apps/nvt-bridge/.env.
 
 # --- Git-identitet for agentens commits (bot-kontoen) ---
-# Kontonavnet holdes i env-config — det skal ikke inn i repoet. Bot-kontoen
-# skal IKKE stå i GITHUB_ALLOWED_USERS.
-GIT_USER_NAME=
-GIT_USER_EMAIL=
+# Settes IKKE her. M0-funn 4: `static_token`-provideren kan ikke rapportere
+# commit-identitet, så den må stå eksplisitt i instansens `agent.yaml`
+# (`identity.mode: explicit`). Den fila genereres av broen, som leser
+# NVT_GIT_IDENTITY_NAME og NVT_GIT_IDENTITY_EMAIL fra apps/nvt-bridge/.env —
+# ett sted, så verdiene ikke kan komme i utakt. Bot-kontoen skal IKKE stå i
+# GITHUB_ALLOWED_USERS.
 
 # --- Broker-grant (settes i nvt, ikke her) ---
 # Navnet på provideren agentens grant peker på, til referanse i
 # `make agent-grant NAME=<instans> PROVIDER=<denne> REPO=<arbeidsrepo>`.
 # Grants er default-deny og auditeres av brokeren. Se issue #96 (M0).
+# MERK: samme verdi må stå som NVT_BROKER_PROVIDER i apps/nvt-bridge/.env —
+# det er den broen skriver inn i instansens agent.yaml.
 NVT_BROKER_PROVIDER=fatdev-github
 
 # Repoene grantet skal gjelde for (komma-separert, owner/repo).
@@ -31,9 +35,9 @@ NVT_GRANT_REPOS=digdir/digdir-ai-agents
 # containeren. Modell-allowlisten håndheves i gatewayen (fail closed) —
 # agenten kan ikke velge en dyrere modell selv.
 #
-# ⚠️ Host-oppslaget må VERIFISERES i M0 (issue #96): nvt-runtimen kjører med
-# `network_mode: service:docker`, så det er ikke gitt at
-# host.docker.internal løses her. Er den ikke det, brukes gateway-IP-en.
+# Host-oppslaget er VERIFISERT i M0 (funn 6): gatewayen svarer 200 OK på
+# host.docker.internal:8787 fra agentcontaineren, tross
+# `network_mode: service:docker`. Ingen gateway-IP-triksing nødvendig.
 ANTHROPIC_BASE_URL=http://host.docker.internal:8787
 ANTHROPIC_AUTH_TOKEN=
 

--- a/agents/nvt-fat-developer/README.md
+++ b/agents/nvt-fat-developer/README.md
@@ -11,11 +11,14 @@ git-token utstedt av nvt-brokeren. Samme filkontrakt som de andre agentene
 Design og premisser: [`doc/plans/nvt-agent-integrasjon.md`](../../doc/plans/nvt-agent-integrasjon.md).
 Sporet er issue #95; denne katalogen og broen er M1 (#97).
 
-> **Status: M1-kjerne, ikke tatt i bruk ennå.** Kjernelogikken i broen er
-> implementert og testet, men oppsettet mot ekte nvt-instanser (compose-stier,
-> containernavn, host-oppslag, broker-grant) **kalibreres mot M0-funnene**
-> (issue #96) før agenten rutes trafikk. Ruta i `AGENT_ROUTES` er driftskonfig
-> og settes ved utrulling, ikke her.
+> **Status: M1-kjerne kalibrert mot M0-funnene, ikke tatt i bruk ennå.** Broen
+> kjører nå `agent-init --user non-root`, venter på at CLI-sesjonen er klar før
+> første prompt, validerer at stiene kan traverseres av uid 1000, og genererer
+> instansens `agent.yaml` med eksplisitt commit-identitet. Ende-til-ende mot en
+> ekte instans er fortsatt ikke kjørt — se
+> [`apps/nvt-bridge/README.md`](../../apps/nvt-bridge/README.md) § «Kalibrert
+> mot M0-funnene», særlig volum-hygienen ved bytte fra root til non-root. Ruta
+> i `AGENT_ROUTES` er driftskonfig og settes ved utrulling, ikke her.
 
 ## Arkitektur
 
@@ -55,7 +58,7 @@ Sporet er issue #95; denne katalogen og broen er M1 (#97).
 | Fil | Rolle |
 | --- | --- |
 | `AGENTS.local.md.tmpl` | Instruks-malen som rendres inn i instansens `AGENTS.local.md`. Agentens protokoll. |
-| `.env.example` | Instans-config (git-identitet, broker-provider, LLM-backend). Ingen tokens — de bor i `.broker/`. |
+| `.env.example` | Instans-config (broker-provider, LLM-backend). Ingen tokens — de bor i `.broker/`. Commit-identiteten settes i broens `.env`. |
 | `triggers/` | Filkontrakten. Gitignorert bortsett fra `.gitkeep`. |
 
 ### Instruks-malen
@@ -87,7 +90,9 @@ kommentaren øverst i malen.
 
 # 2) Broen
 Copy-Item apps\nvt-bridge\.env.example apps\nvt-bridge\.env
-# fyll inn NVT_ROOT (nvt-sjekkouten) — se apps/nvt-bridge/README.md
+# fyll inn NVT_ROOT (en sti uid 1000 kan traversere, f.eks. /srv/nvt-agent),
+# NVT_GIT_IDENTITY_NAME/EMAIL og NVT_BROKER_PROVIDER — broen nekter å starte
+# uten. Se apps/nvt-bridge/README.md
 cd apps\nvt-bridge; npm start
 
 # 3) Ruta (driftskonfig, i deploy-klonens .env — ikke i dette repoet)

--- a/apps/nvt-bridge/.env.example
+++ b/apps/nvt-bridge/.env.example
@@ -28,15 +28,29 @@ NVT_BRIDGE_PROMPT_TIMEOUT_SECONDS=3600
 # resultatlinja før bridgen skriver en status:"error"-linje i stedet.
 NVT_BRIDGE_RESULT_GRACE_SECONDS=60
 
+# Hvor lenge klar-sjekken venter på at CLI-sesjonen kan ta imot en prompt
+# (M0-funn 5: claude-onboardingen spiser prompts som kommer for tidlig).
+# Blir sesjonen ikke klar, sendes INGEN prompt — eventet får en error-linje.
+NVT_BRIDGE_READY_TIMEOUT_SECONDS=180
+
+# Sekunder mellom hver runde i klar-sjekken.
+NVT_BRIDGE_READY_POLL_SECONDS=2
+
+# Maks antall Enter broen sender for å komme gjennom onboarding-dialogene.
+# Enter sendes bare når en dialog faktisk står i panelet, aldri i blinde.
+NVT_BRIDGE_MAX_ONBOARDING_ENTER=3
+
 # TTL: inaktive topics tas ned med `agent-down` etter så mange minutter.
 # Workspacet beholdes, så instansen kan gjenskapes. 0 = aldri ta ned.
 NVT_BRIDGE_IDLE_TTL_MINUTES=180
 
-# --- nvt-oppsettet (kalibreres mot M0-funn, se issue #96) ---
-# Sjekkouten av nvt-agent. Make-flyten (agent-init/agent-up) kjøres herfra.
-# MERK: når bridgen kjører i container, må denne stien være IDENTISK med
+# --- nvt-oppsettet (kalibrert mot M0-funnene, se issue #96) ---
+# Sjekkouten av nvt-agent. agent-init/agent-up kjøres herfra.
+# MERK 1: når bridgen kjører i container, må denne stien være IDENTISK med
 # stien på hosten — compose-bind-mounts løses av hostens daemon.
-NVT_ROOT=/home/<bruker>/src/nvt-agent
+# MERK 2 (M0-funn 2): stien må kunne traverseres av uid 1000. /root (mode 0700)
+# virker IKKE — broen nekter å starte. Bruk f.eks. /srv/nvt-agent.
+NVT_ROOT=/srv/nvt-agent
 
 # Sjekkouten av digdir-ai-agents-pipelinen. Brukes for triggers-sti.
 # MERK: samme identitetskrav som NVT_ROOT — må være absolutt host-sti.
@@ -47,6 +61,53 @@ RESTART_POLICY=unless-stopped
 
 # Agent-type nvt skal initialisere instansene med.
 NVT_AGENT_TYPE=claude
+
+# --autonomy til agent-init. trusted-local gir claude bypass-flagget
+# (containeren er isolasjonsgrensen, jf. planen).
+NVT_AGENT_AUTONOMY=trusted-local
+
+# --user til agent-init. M0-funn 1: claude NEKTER bypass-flagget som root, og
+# tmux-sesjonen dør innen 5 s. La denne stå på non-root.
+# MERK: bytter du en EKSISTERENDE instans fra root til non-root, må
+# agent-<navn>_agent-home og agent-<navn>_docker-data slettes først — se README.
+NVT_AGENT_USER_MODE=non-root
+
+# tmux-sesjonen agenten kjører i (AGENT_SESSION i nvt). Klar-sjekken leser
+# panelet i denne sesjonen.
+NVT_AGENT_TMUX_SESSION=agent
+
+# Mønstre for klar-sjekken (case-insensitive regex). Tomt = innebygde
+# defaults, som er kalibrert mot claude-TUI-et slik det ser ut nå. Bytter
+# claude ordlyd, er dette stedet å rette — ingen kodeendring nødvendig.
+# NVT_READY_PATTERN=\? for shortcuts|Bypassing Permissions
+# NVT_ONBOARDING_PATTERN=Do you trust the files|Press Enter to continue
+
+# Sett til 1 for å hoppe over sti-sjekken mot uid 1000 (se NVT_ROOT).
+# Aktuelt på macOS, der Docker Desktop mapper eierskap selv.
+NVT_BRIDGE_SKIP_PATH_CHECK=0
+
+# --- Commit-identitet og git-tilgang i instansen (M0-funn 4) ---
+# Broen genererer .agents/<navn>/agent.yaml med identity.mode: explicit.
+# 'mode: provider' virker IKKE for broker-token/static_token — agenten ender
+# uten commit-identitet og `git commit` feiler etter at jobben er gjort.
+#
+# Bot-kontoens navn og e-post. Holdes utenfor repoet med vilje. Uten disse
+# nekter broen å starte. Bot-kontoen skal IKKE i GITHUB_ALLOWED_USERS.
+NVT_GIT_IDENTITY_NAME=
+NVT_GIT_IDENTITY_EMAIL=
+
+# Navnet på providerens grant i brokeren (.broker/agents.yaml) — den som
+# holder bot-PAT-en som static_token. Tokenverdien bor kun i .broker/env på
+# hosten, aldri i instansen eller i dette repoet.
+NVT_BROKER_PROVIDER=
+
+# Providernavnet inne i instansen (fritt valgt, refereres fra agent.yaml).
+NVT_GIT_PROVIDER=fatdev-broker
+
+# Hvilke repoer credential-provideren gjelder for. targetMatch er en glob mot
+# normalisert repo-target; urlMatch er URL-prefikset git-regelen treffer på.
+NVT_GIT_TARGET_MATCH=github.com/digdir/*
+NVT_GIT_URL_MATCH=https://github.com/digdir/
 
 # Hvor agentens triggers/ er mountet INNE i instansen. Brukes i prompten som
 # forteller agenten hvor resultatlinja skal. Mounten settes opp i nvt-configen

--- a/apps/nvt-bridge/README.md
+++ b/apps/nvt-bridge/README.md
@@ -114,13 +114,19 @@ instans, hent det ut via code-server først.
 Workspacet bind-mountes på samme absolutte sti inne i containeren, og agenten
 er `1000:1000`. Ligger `NVT_ROOT` under `/root` (mode 0700), feiler bootstrap
 inne i containeren med en kryptisk `Permission denied`. Broen sjekker derfor
-hele stien til `NVT_ROOT` og triggers-katalogen ved oppstart og **nekter å
-starte** med en melding om hvilket ledd som stopper uid 1000. Bruk f.eks.
+hele stien til `NVT_ROOT` og triggers-katalogen ved oppstart — sistnevnte også
+for *skrive*tilgang, siden agenten appender resultatlinja selv. Symlenker løses
+først, så en lenke ikke kan skjule at målets foreldre er stengt. Bruk f.eks.
 `/srv/nvt-agent`.
 
-Sjekken håndheves bare på Linux — Docker Desktop på macOS mapper eierskap i
-virtiofs-laget, så host-mode-bitene der ville gitt falske avvisninger. Der
-logges funnet som en advarsel. `NVT_BRIDGE_SKIP_PATH_CHECK=1` slår den av helt.
+**Hva sjekken faktisk kan svare på:** mode-bitene broen leser må være hostens.
+Det stemmer når broen kjører som node-prosess på hosten (`npm start`) — da
+**nekter den å starte** med en melding om hvilket ledd som stopper uid 1000.
+Kjører broen selv i container, er bare `NVT_ROOT` og triggers-katalogen
+bind-mountet; mellomleddene er mount-point-foreldre Docker har laget, med helt
+andre rettigheter enn hostens. Da logges funnet som en **advarsel** i stedet, og
+stien må kontrolleres på hosten. Samme gjelder macOS, der Docker Desktop mapper
+eierskap i virtiofs-laget. `NVT_BRIDGE_SKIP_PATH_CHECK=1` slår sjekken av helt.
 
 ### 4. Commit-identitet må være eksplisitt i `agent.yaml`
 
@@ -142,11 +148,29 @@ som injiseres da forsvinner **uten spor** — ingen feil, ingen `signal done`,
 bare en timeout en time senere. `agentd` venter selv på
 `session-launched`-markøren og tmux-sesjonen, men vet ikke om dialogene.
 
-Broen krever derfor tre ting før første prompt: markøren finnes, tmux-sesjonen
-svarer, og panelet (`tmux capture-pane`) viser en klar-prompt. Står en dialog
-der, sendes ett Enter per runde (maks `NVT_BRIDGE_MAX_ONBOARDING_ENTER`, default
-3). Enter sendes **aldri** i blinde: inn i en sesjon som venter på svar ville
-det sendt av halvskrevet input.
+Onboardingen er en **sesjonsstart**-tilstand, så gaten har to nivåer:
+
+| Tilstand | Krav før prompten sendes |
+| --- | --- |
+| Fersk sesjon (klar-prompten er ikke sett i denne container-inkarnasjonen) | Markøren finnes, tmux svarer, og panelet (`tmux capture-pane`) viser klar-prompt. Står en onboarding-dialog der, sendes ett Enter per runde (maks `NVT_BRIDGE_MAX_ONBOARDING_ENTER`, default 3). |
+| Bekreftet sesjon | Markøren finnes og tmux-sesjonen lever. Panelet leses ikke. |
+
+Enter sendes altså aldri i blinde — bare når en dialog faktisk er tegnet i en
+sesjon som ikke har vært i bruk.
+
+To detaljer som er verdt å kjenne:
+
+- **Panelet leses bare på en fersk sesjon**, fordi det ellers inneholder
+  transkriptet — inkludert den delegerte oppgaveteksten, som er upålitelig
+  input. Lot vi den styre gaten, kunne en avsender som skrev
+  «Do you trust the files in this folder?» i oppgaven fått broen til å tro at en
+  dialog sto der, og dermed blokkert topicet. Mønstrene er i tillegg
+  linjeankret, slik at et ekko av oppgaveteksten (som står bak en `>`-prompt)
+  ikke matcher.
+- **Klar-tilstanden gjelder én container-inkarnasjon** (`docker inspect` sin
+  `Id` + `StartedAt`). Restartes containeren utenfor broen — `docker restart`,
+  host-reboot med `restart: unless-stopped` — er det en ny sesjon med ny
+  onboarding, og gaten blir streng igjen selv om broen aldri kjørte `agent-up`.
 
 Blir sesjonen ikke klar innen `NVT_BRIDGE_READY_TIMEOUT_SECONDS`, kaster
 sjekken, prompten sendes ikke, og eventet får en `status:"error"`-linje med
@@ -154,10 +178,10 @@ peker til code-server. Feilmeldingen gjengir **ikke** panelinnholdet — den gå
 videre til Slack, og en tmux-skjerm kan inneholde hva som helst.
 
 Mønstergjenkjenning mot et TUI er heuristikk. Bytter claude ordlyd, kan
-mønstrene settes med `NVT_READY_PATTERN` / `NVT_ONBOARDING_PATTERN` uten
-kodeendring. Etter at klar-prompten er sett én gang i en sesjon, godtar broen
-«lever, ingen dialog» for de neste promptene — da kan agenten være midt i
-arbeid, og `agentd` køer prompten selv.
+mønstrene settes med `NVT_READY_PATTERN` / `NVT_ONBOARDING_PATTERN` (regex,
+case-insensitive) uten kodeendring. Feiler klar-mønsteret å matche en sesjon som
+*er* klar, blir utfallet en ærlig feilmelding og en uendret innboks — ikke en
+tapt oppgave.
 
 ## Oppstart
 

--- a/apps/nvt-bridge/README.md
+++ b/apps/nvt-bridge/README.md
@@ -9,12 +9,13 @@ Rollen tilsvarer `scripts/agent-runner.ps1` for engangs-container-agentene,
 men mot nvt i stedet for `docker run`. Design: [`doc/plans/nvt-agent-integrasjon.md`](../../doc/plans/nvt-agent-integrasjon.md).
 Sporet er issue #95; dette er M1 (#97).
 
-> **Status: kjernen er implementert og testet; oppsettet mot ekte
-> nvt-instanser er ikke verifisert.** Alt som antar noe om nvt (make-mål,
-> containernavn, `agentdctl`-format) ligger isolert i
-> [`src/nvt/docker.ts`](src/nvt/docker.ts) og er merket «kalibreres mot
-> M0-funn» (issue #96). Kjernelogikken testes mot en fake-implementasjon og er
-> uavhengig av hvordan den fila ender opp.
+> **Status: kjernen er implementert og testet, og adapteren er kalibrert mot
+> M0-funnene — men ikke kjørt ende-til-ende mot en ekte instans.** Alt som
+> antar noe om nvt (init-flyten, containernavn, `agentdctl`-format,
+> klar-mønstre) ligger isolert i [`src/nvt/docker.ts`](src/nvt/docker.ts).
+> Kjernelogikken testes mot en fake-implementasjon og er uavhengig av hvordan
+> den fila ender opp. Hva som fortsatt er uverifisert står i kommentaren øverst
+> i fila.
 
 ## Hva den gjør
 
@@ -24,14 +25,18 @@ Sporet er issue #95; dette er M1 (#97).
    `-d2`, …), ellers eventets egen id. Topicet er opphavstråden, så
    oppfølgingsevents havner i samme instans og samme samtale.
 3. **Mapper topic → instans** i `state/topics.json`. Finnes ingen instans:
-   `agent-init` + `agent-up`. Finnes den: gjenbruk den levende sesjonen.
-4. **Injiserer prompten**:
+   `agent-init --user non-root` + `agent-up`. Finnes den: gjenbruk den levende
+   sesjonen.
+4. **Venter til sesjonen er klar** — `session-launched`-markøren finnes,
+   tmux-sesjonen svarer, og panelet viser ikke en onboarding-dialog. Se
+   «Klar-sjekken» under.
+5. **Injiserer prompten**:
    `docker exec <instans> agentdctl prompt --source host --external`.
    `--external` er ikke valgfritt — delegerte prompts er upålitelig input, og
    flagget gir nvt sin «untrusted input»-preamble.
-5. **Venter** på `agentdctl signal done`, og verifiserer at agenten faktisk
+6. **Venter** på `agentdctl signal done`, og verifiserer at agenten faktisk
    skrev resultatlinja.
-6. **Rydder**: `agent-down` for topics som har vært stille lenger enn TTL.
+7. **Rydder**: `agent-down` for topics som har vært stille lenger enn TTL.
    Workspacet beholdes, så instansen kan gjenskapes med samme arbeidskopi.
 
 Serielt innen et topic, parallelt på tvers (maks N). Serialiseringen er ikke
@@ -71,6 +76,88 @@ midt i arbeidet ville vært verre enn et ærlig «ukjent utfall». Broen venter
 nådefristen på at agenten skriver linja selv, og melder ellers feil med peker
 til instansen. Ved `SIGTERM`/`SIGINT` avslutter broen først når events under
 arbeid har fått skrevet resultatlinja si.
+
+## Kalibrert mot M0-funnene
+
+M0 (issue #96) kjørte hele kjeden manuelt og traff fem feller. Alle er
+adressert i adapteren; her er hva du som drifter må vite.
+
+### 1. Agenten kjører som non-root — ellers dør sesjonen
+
+claude nekter `--dangerously-skip-permissions` som root, og tmux-sesjonen dør
+innen 5 sekunder (tre forsøk, så exit). Broen kjører derfor
+`agent-init --user non-root`, som gir `AGENT_RUN_USER=1000:1000`.
+
+Merk at dette **ikke** går via `make agent-init`: make-målet kaller
+`scripts/agent-init.sh --name --type --autonomy` og forwarder ikke `--user`.
+Broen kaller scriptet direkte. `agent-up`/`agent-down` går fortsatt gjennom
+make.
+
+### 2. Volum-hygiene ved bytte root → non-root
+
+Named-volumene til en instans som *allerede* har kjørt som root beholder
+root-eierskapet, og bootstrap feiler med `Permission denied` selv etter at
+configen er rettet. Volumene må slettes:
+
+```bash
+make agent-down NAME=<navn>
+docker volume rm agent-<navn>_agent-home agent-<navn>_docker-data
+```
+
+Dette gjelder bare instanser opprettet før kalibreringen. Workspacet ligger i
+nvt-sjekkouten, ikke i volumene, men **alt som bare fantes i agentens
+`$HOME`** (CLI-state, cacher) forsvinner. Har du ikke-pushet arbeid i en slik
+instans, hent det ut via code-server først.
+
+### 3. Stier uid 1000 kan traversere
+
+Workspacet bind-mountes på samme absolutte sti inne i containeren, og agenten
+er `1000:1000`. Ligger `NVT_ROOT` under `/root` (mode 0700), feiler bootstrap
+inne i containeren med en kryptisk `Permission denied`. Broen sjekker derfor
+hele stien til `NVT_ROOT` og triggers-katalogen ved oppstart og **nekter å
+starte** med en melding om hvilket ledd som stopper uid 1000. Bruk f.eks.
+`/srv/nvt-agent`.
+
+Sjekken håndheves bare på Linux — Docker Desktop på macOS mapper eierskap i
+virtiofs-laget, så host-mode-bitene der ville gitt falske avvisninger. Der
+logges funnet som en advarsel. `NVT_BRIDGE_SKIP_PATH_CHECK=1` slår den av helt.
+
+### 4. Commit-identitet må være eksplisitt i `agent.yaml`
+
+`static_token`/broker-token-providere kan ikke rapportere commit-identitet, så
+`identity.mode: provider` (som står i nvt-malens kommenterte eksempel) gir en
+agent uten identitet — og `git commit` feiler *etter* at jobben er gjort.
+
+Broen genererer derfor `.agents/<navn>/agent.yaml` selv, med
+`identity.mode: explicit` og navn/e-post fra `NVT_GIT_IDENTITY_NAME` og
+`NVT_GIT_IDENTITY_EMAIL`. Bot-navnet ligger bevisst i env, ikke i repoet.
+Configen skrives **én gang**, før `agent-init`; en eksisterende config røres
+aldri (den kan være håndredigert), men identiteten verifiseres ved hver
+oppstart, og `mode: provider` stopper broen med en forklaring.
+
+### 5. Klar-sjekken: onboardingen spiser første prompt
+
+claude-onboardingen (velkomstskjerm, trust-dialog) fanger tastetrykk. En prompt
+som injiseres da forsvinner **uten spor** — ingen feil, ingen `signal done`,
+bare en timeout en time senere. `agentd` venter selv på
+`session-launched`-markøren og tmux-sesjonen, men vet ikke om dialogene.
+
+Broen krever derfor tre ting før første prompt: markøren finnes, tmux-sesjonen
+svarer, og panelet (`tmux capture-pane`) viser en klar-prompt. Står en dialog
+der, sendes ett Enter per runde (maks `NVT_BRIDGE_MAX_ONBOARDING_ENTER`, default
+3). Enter sendes **aldri** i blinde: inn i en sesjon som venter på svar ville
+det sendt av halvskrevet input.
+
+Blir sesjonen ikke klar innen `NVT_BRIDGE_READY_TIMEOUT_SECONDS`, kaster
+sjekken, prompten sendes ikke, og eventet får en `status:"error"`-linje med
+peker til code-server. Feilmeldingen gjengir **ikke** panelinnholdet — den går
+videre til Slack, og en tmux-skjerm kan inneholde hva som helst.
+
+Mønstergjenkjenning mot et TUI er heuristikk. Bytter claude ordlyd, kan
+mønstrene settes med `NVT_READY_PATTERN` / `NVT_ONBOARDING_PATTERN` uten
+kodeendring. Etter at klar-prompten er sett én gang i en sesjon, godtar broen
+«lever, ingen dialog» for de neste promptene — da kan agenten være midt i
+arbeid, og `agentd` køer prompten selv.
 
 ## Oppstart
 
@@ -120,9 +207,12 @@ node-prosess under WSL2; koden er den samme.
 | `src/prompt.ts` | Prompten som injiseres, og fallback-forklaringene |
 | `src/bridge.ts` | Orkestreringen og fallback-invariantene |
 | `src/nvt/driver.ts` | Interfacet mot nvt |
-| `src/nvt/fake.ts` | Fake-implementasjon for tester |
+| `src/nvt/fake.ts` | Fake-implementasjon for tester (håndhever klar-sjekk før prompt) |
 | `src/nvt/dryrun.ts` | Tørrkjøring |
-| `src/nvt/docker.ts` | **Ekte adapter — kalibreres mot M0-funn** |
+| `src/nvt/docker.ts` | **Ekte adapter — kalibrert mot M0-funnene** |
+| `src/nvt/ready.ts` | Klar-tilstand: klassifisering av tmux-panelet |
+| `src/nvt/paths.ts` | Sti-validering mot uid 1000 (fail-fast ved oppstart) |
+| `src/nvt/agentConfig.ts` | `agent.yaml` med eksplisitt commit-identitet |
 
 Node ≥ 22.6, ingen runtime-avhengigheter, ingen byggesteg (native
 type-stripping), `node --test` — samme stack som `integrations/`.

--- a/apps/nvt-bridge/src/bridge.test.ts
+++ b/apps/nvt-bridge/src/bridge.test.ts
@@ -42,6 +42,7 @@ async function harness(overrides: HarnessOptions = {}): Promise<Harness> {
     instanceNaming: { prefix: "fatdev", maxLength: 40 },
     maxParallel: overrides.maxParallel ?? 4,
     promptTimeoutMs: 1000,
+    readyTimeoutMs: 1000,
     resultGraceMs: overrides.resultGraceMs ?? 0,
     idleTtlMs: 0,
     // Ingen ekte venting i tester — men vi husker hvor lenge det ble ventet.
@@ -190,6 +191,48 @@ test("to topics kjører i hver sin instans uten å påvirke hverandre", async ()
 
   assert.equal(h.driver.everCreated.size, 2);
   assert.equal((await h.results()).length, 2);
+});
+
+test("klar-sjekken kommer før prompten, hver gang (M0-funn 5)", async () => {
+  const h = await harness();
+  h.driver.onPrompt = () => ({ kind: "timeout", waitedMs: 1 });
+
+  await h.push(evt("e1-d1", "topic-1"));
+  await h.bridge.pollOnce();
+  await h.bridge.scheduler.idle();
+  await h.push(evt("e1-d2", "topic-1"));
+  await h.bridge.pollOnce();
+  await h.bridge.scheduler.idle();
+
+  assert.deepEqual(
+    h.driver.calls.map((c) => c.kind),
+    ["ensure", "ready", "prompt", "wait", "ensure", "ready", "prompt", "wait"],
+    "også oppfølgingsprompten skal ha en klar-sjekk foran seg",
+  );
+});
+
+test("en sesjon som ikke blir klar gir status:error, og prompten sendes ikke", async () => {
+  const h = await harness();
+  h.driver.onReady = () => {
+    throw new Error("sesjonen i fatdev-x ble ikke klar innen 180s (panel: onboarding)");
+  };
+
+  await h.push(evt("e1", "topic-1"));
+  await h.bridge.pollOnce();
+  await h.bridge.scheduler.idle();
+
+  assert.equal(
+    h.driver.calls.some((c) => c.kind === "prompt"),
+    false,
+    "en prompt inn i onboardingen forsvinner uten spor — den skal ikke sendes",
+  );
+  const [line] = await h.results();
+  assert.equal(line!.status, "error");
+  assert.match(line!.reply!, /ble ikke klar/);
+  assert.match(line!.reply!, /Ingen leveranse er bekreftet/);
+  // Eventet er ikke injisert, så det skal ikke stå som «under arbeid» og
+  // blokkere topicet etter en omstart.
+  assert.equal(h.store.get("topic-1")?.in_flight_event_id, undefined);
 });
 
 test("prompts inn i samme sesjon er alltid serielle", async () => {
@@ -430,6 +473,7 @@ test("triggers-stien i prompten er konfigurerbar", async () => {
     instanceNaming: { prefix: "fatdev", maxLength: 40 },
     maxParallel: 1,
     promptTimeoutMs: 10,
+    readyTimeoutMs: 1000,
     resultGraceMs: 0,
     idleTtlMs: 0,
     instanceTriggersPath: "/mnt/triggers",
@@ -515,6 +559,7 @@ test("TTL tar ned inaktive topics, men beholder state og workspace", async () =>
     instanceNaming: { prefix: "fatdev", maxLength: 40 },
     maxParallel: 2,
     promptTimeoutMs: 10,
+    readyTimeoutMs: 1000,
     resultGraceMs: 0,
     idleTtlMs: 1, // alt er "inaktivt" med en gang
     sleep: async () => {},
@@ -554,6 +599,7 @@ test("TTL rører ikke et topic som har arbeid i kø", async () => {
     instanceNaming: { prefix: "fatdev", maxLength: 40 },
     maxParallel: 2,
     promptTimeoutMs: 10,
+    readyTimeoutMs: 1000,
     resultGraceMs: 0,
     idleTtlMs: 1,
     sleep: async () => {},

--- a/apps/nvt-bridge/src/bridge.ts
+++ b/apps/nvt-bridge/src/bridge.ts
@@ -15,6 +15,8 @@ export interface BridgeOptions {
   maxParallel: number;
   /** Hvor lenge vi venter på `agentdctl signal done`. */
   promptTimeoutMs: number;
+  /** Hvor lenge vi venter på at sesjonen blir klar til å ta imot prompten. */
+  readyTimeoutMs: number;
   /** Nådefrist for resultatlinja etter `signal done`. */
   resultGraceMs: number;
   /** TTL for `agent-down` av inaktive topics. 0 = av. */
@@ -150,6 +152,15 @@ export class NvtBridge {
       const instance = record?.instance ?? instanceName;
 
       const ref = await this.opts.driver.ensureInstance(topic, instance);
+
+      // Klar-sjekk FØR markeringen og prompten (M0-funn 5): en prompt som
+      // injiseres i claude-onboardingen forsvinner uten spor — ingen feil,
+      // ingen `signal done`, bare en timeout på slutten. Kaster sjekken, er
+      // ingen prompt sendt, og eventet skal ikke stå som injisert.
+      await this.opts.driver.waitUntilReady(ref, {
+        timeoutMs: this.opts.readyTimeoutMs,
+        signal: this.abortSignal,
+      });
       this.log(`topic ${topic}: instans ${instance} klar, injiserer event ${event.id}`);
 
       // Markeres FØR prompten sendes: krasjer bridgen mellom disse to, må

--- a/apps/nvt-bridge/src/config.ts
+++ b/apps/nvt-bridge/src/config.ts
@@ -1,4 +1,11 @@
 import path from "node:path";
+import type { AgentConfigVars } from "./nvt/agentConfig.ts";
+import {
+  DEFAULT_ONBOARDING_PATTERN,
+  DEFAULT_READY_PATTERN,
+  patternFromEnv,
+  type PanePatterns,
+} from "./nvt/ready.ts";
 import type { InstanceNameOptions } from "./topic.ts";
 
 export interface BridgeConfig {
@@ -11,9 +18,24 @@ export interface BridgeConfig {
   idleTtlMs: number;
   nvtRoot: string;
   agentType: string;
+  /** `--autonomy` til `agent-init`. */
+  autonomy: string;
+  /** `--user` til `agent-init`. `non-root` er det eneste som virker (M0-funn 1). */
+  userMode: string;
+  /** tmux-sesjonen agenten kjører i. */
+  tmuxSession: string;
+  /** Hvor lenge klar-sjekken venter før den gir opp (M0-funn 5). */
+  readyTimeoutMs: number;
+  readyPollMs: number;
+  maxEnterPresses: number;
+  panePatterns: PanePatterns;
+  /** Identitet og provider til `agent.yaml` (M0-funn 4). */
+  agentConfig: Omit<AgentConfigVars, "agentType" | "runtimeArgs" | "userMode">;
   instanceNaming: InstanceNameOptions;
   /** Hvor agentens triggers/ er mountet inne i instansen. */
   instanceTriggersPath: string;
+  /** Hopp over sti-sjekken mot uid 1000 (M0-funn 2). */
+  skipPathCheck: boolean;
   dryRun: boolean;
 }
 
@@ -29,6 +51,35 @@ export function loadConfig(
         "Kopiér .env.example til .env.",
     );
   }
+
+  const userMode = (env.NVT_AGENT_USER_MODE ?? "non-root").trim();
+  if (userMode !== "non-root" && userMode !== "root") {
+    throw new Error(`NVT_AGENT_USER_MODE: forventet "non-root" eller "root", fikk "${userMode}"`);
+  }
+
+  // Commit-identiteten må stå eksplisitt i agent.yaml (M0-funn 4), og
+  // bot-navnet skal ikke i repoet — derfor env, uten default. Mangler den,
+  // ville agenten jobbet en time og så feilet på `git commit`.
+  const identityName = (env.NVT_GIT_IDENTITY_NAME ?? "").trim();
+  const identityEmail = (env.NVT_GIT_IDENTITY_EMAIL ?? "").trim();
+  const brokerProvider = (env.NVT_BROKER_PROVIDER ?? "").trim();
+  if (!dryRun) {
+    const missing = [
+      ["NVT_GIT_IDENTITY_NAME", identityName],
+      ["NVT_GIT_IDENTITY_EMAIL", identityEmail],
+      ["NVT_BROKER_PROVIDER", brokerProvider],
+    ]
+      .filter(([, value]) => value === "")
+      .map(([name]) => name);
+    if (missing.length > 0) {
+      throw new Error(
+        `Mangler ${missing.join(", ")}. Uten commit-identitet og broker-provider kan ` +
+          `instansens agent.yaml ikke genereres (M0-funn 4), og agenten får ikke committet. ` +
+          `Se .env.example.`,
+      );
+    }
+  }
+
   return {
     triggersDir: path.resolve(
       cwd,
@@ -46,7 +97,38 @@ export function loadConfig(
       intFrom(env.NVT_BRIDGE_IDLE_TTL_MINUTES, 180, "NVT_BRIDGE_IDLE_TTL_MINUTES", 0) * 60_000,
     nvtRoot,
     agentType: (env.NVT_AGENT_TYPE ?? "claude").trim(),
+    autonomy: (env.NVT_AGENT_AUTONOMY ?? "trusted-local").trim(),
+    userMode,
+    tmuxSession: (env.NVT_AGENT_TMUX_SESSION ?? "agent").trim(),
+    readyTimeoutMs:
+      intFrom(env.NVT_BRIDGE_READY_TIMEOUT_SECONDS, 180, "NVT_BRIDGE_READY_TIMEOUT_SECONDS", 1) *
+      1000,
+    readyPollMs:
+      intFrom(env.NVT_BRIDGE_READY_POLL_SECONDS, 2, "NVT_BRIDGE_READY_POLL_SECONDS", 1) * 1000,
+    maxEnterPresses: intFrom(
+      env.NVT_BRIDGE_MAX_ONBOARDING_ENTER,
+      3,
+      "NVT_BRIDGE_MAX_ONBOARDING_ENTER",
+      0,
+    ),
+    panePatterns: {
+      ready: patternFromEnv(env.NVT_READY_PATTERN, DEFAULT_READY_PATTERN, "NVT_READY_PATTERN"),
+      onboarding: patternFromEnv(
+        env.NVT_ONBOARDING_PATTERN,
+        DEFAULT_ONBOARDING_PATTERN,
+        "NVT_ONBOARDING_PATTERN",
+      ),
+    },
+    agentConfig: {
+      gitProvider: (env.NVT_GIT_PROVIDER ?? "fatdev-broker").trim(),
+      brokerProvider,
+      targetMatch: (env.NVT_GIT_TARGET_MATCH ?? "github.com/digdir/*").trim(),
+      urlMatch: (env.NVT_GIT_URL_MATCH ?? "https://github.com/digdir/").trim(),
+      identityName,
+      identityEmail,
+    },
     instanceTriggersPath: (env.NVT_INSTANCE_TRIGGERS_PATH ?? "/triggers").trim(),
+    skipPathCheck: boolFrom(env.NVT_BRIDGE_SKIP_PATH_CHECK),
     instanceNaming: {
       prefix: (env.NVT_INSTANCE_PREFIX ?? "fatdev").trim(),
       maxLength: intFrom(env.NVT_INSTANCE_NAME_MAX, 40, "NVT_INSTANCE_NAME_MAX", 16),

--- a/apps/nvt-bridge/src/config.ts
+++ b/apps/nvt-bridge/src/config.ts
@@ -57,6 +57,20 @@ export function loadConfig(
     throw new Error(`NVT_AGENT_USER_MODE: forventet "non-root" eller "root", fikk "${userMode}"`);
   }
 
+  // Valideres her, ikke per event: `agent-init` og runtime-argumentene i
+  // agent.yaml støtter bare disse to. Ellers hadde broen startet fint og feilet
+  // først når en oppgave kom — én feilmelding til Slack per delegering.
+  const agentType = (env.NVT_AGENT_TYPE ?? "claude").trim();
+  if (agentType !== "claude" && agentType !== "codex") {
+    throw new Error(`NVT_AGENT_TYPE: forventet "claude" eller "codex", fikk "${agentType}"`);
+  }
+  const autonomy = (env.NVT_AGENT_AUTONOMY ?? "trusted-local").trim();
+  if (autonomy !== "trusted-local" && autonomy !== "interactive") {
+    throw new Error(
+      `NVT_AGENT_AUTONOMY: forventet "trusted-local" eller "interactive", fikk "${autonomy}"`,
+    );
+  }
+
   // Commit-identiteten må stå eksplisitt i agent.yaml (M0-funn 4), og
   // bot-navnet skal ikke i repoet — derfor env, uten default. Mangler den,
   // ville agenten jobbet en time og så feilet på `git commit`.
@@ -96,8 +110,8 @@ export function loadConfig(
     idleTtlMs:
       intFrom(env.NVT_BRIDGE_IDLE_TTL_MINUTES, 180, "NVT_BRIDGE_IDLE_TTL_MINUTES", 0) * 60_000,
     nvtRoot,
-    agentType: (env.NVT_AGENT_TYPE ?? "claude").trim(),
-    autonomy: (env.NVT_AGENT_AUTONOMY ?? "trusted-local").trim(),
+    agentType,
+    autonomy,
     userMode,
     tmuxSession: (env.NVT_AGENT_TMUX_SESSION ?? "agent").trim(),
     readyTimeoutMs:

--- a/apps/nvt-bridge/src/index.ts
+++ b/apps/nvt-bridge/src/index.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "./config.ts";
 import { DockerNvtDriver } from "./nvt/docker.ts";
 import { DryRunNvtDriver } from "./nvt/dryrun.ts";
 import type { NvtDriver } from "./nvt/driver.ts";
+import { assertAgentCanTraverse } from "./nvt/paths.ts";
 import { TopicStore } from "./state.ts";
 import { TriggerFiles } from "./triggers.ts";
 
@@ -21,12 +22,42 @@ try {
 
 const config = loadConfig();
 
+// Sti-validering FØR noe annet (M0-funn 2): ligger nvt-sjekkouten eller
+// triggers-katalogen bak en katalog uid 1000 ikke kommer gjennom (klassikeren
+// er /root, mode 0700), feiler bootstrap inne i containeren med en kryptisk
+// «Permission denied» langt fra årsaken. Da er det bedre å ikke starte.
+if (!config.dryRun) {
+  const pathCheck = { skip: config.skipPathCheck, log };
+  await assertAgentCanTraverse("NVT_ROOT", config.nvtRoot, pathCheck);
+  await assertAgentCanTraverse("NVT_BRIDGE_TRIGGERS_DIR", config.triggersDir, pathCheck);
+}
+
 const driver: NvtDriver = config.dryRun
   ? new DryRunNvtDriver(log)
-  : new DockerNvtDriver({ nvtRoot: config.nvtRoot, agentType: config.agentType, log });
+  : new DockerNvtDriver({
+      nvtRoot: config.nvtRoot,
+      agentType: config.agentType,
+      autonomy: config.autonomy,
+      userMode: config.userMode,
+      tmuxSession: config.tmuxSession,
+      agentConfig: config.agentConfig,
+      panePatterns: config.panePatterns,
+      readyPollMs: config.readyPollMs,
+      maxEnterPresses: config.maxEnterPresses,
+      log,
+    });
 
 if (config.dryRun) {
   log("TØRRKJØRING (NVT_BRIDGE_DRY_RUN=1): ingen nvt-instanser startes");
+}
+if (config.userMode !== "non-root") {
+  // M0-funn 1: claude nekter --dangerously-skip-permissions som root, og
+  // tmux-sesjonen dør innen 5 s. Vi stopper ikke — codex/interactive kan ha
+  // andre behov — men det skal stå i loggen når det går galt.
+  log(
+    `ADVARSEL: NVT_AGENT_USER_MODE=${config.userMode}. claude nekter bypass-flagget som root ` +
+      `(M0-funn 1) og sesjonen dør innen 5 s. Bruk non-root.`,
+  );
 }
 
 const bridge = new NvtBridge({
@@ -36,6 +67,7 @@ const bridge = new NvtBridge({
   instanceNaming: config.instanceNaming,
   maxParallel: config.maxParallel,
   promptTimeoutMs: config.promptTimeoutMs,
+  readyTimeoutMs: config.readyTimeoutMs,
   resultGraceMs: config.resultGraceMs,
   idleTtlMs: config.idleTtlMs,
   instanceTriggersPath: config.instanceTriggersPath,

--- a/apps/nvt-bridge/src/index.ts
+++ b/apps/nvt-bridge/src/index.ts
@@ -29,7 +29,12 @@ const config = loadConfig();
 if (!config.dryRun) {
   const pathCheck = { skip: config.skipPathCheck, log };
   await assertAgentCanTraverse("NVT_ROOT", config.nvtRoot, pathCheck);
-  await assertAgentCanTraverse("NVT_BRIDGE_TRIGGERS_DIR", config.triggersDir, pathCheck);
+  // Agenten skriver resultatlinja selv, så triggers/ må også være skrivbar for
+  // uid 1000 — ellers ender hvert event i fallback-feil etter en time.
+  await assertAgentCanTraverse("NVT_BRIDGE_TRIGGERS_DIR", config.triggersDir, {
+    ...pathCheck,
+    requireWrite: true,
+  });
 }
 
 const driver: NvtDriver = config.dryRun

--- a/apps/nvt-bridge/src/nvt/agentConfig.test.ts
+++ b/apps/nvt-bridge/src/nvt/agentConfig.test.ts
@@ -93,6 +93,22 @@ test("identityMode bryr seg ikke om kommentarer", () => {
   assert.equal(identityMode(yaml).kind, "explicit");
 });
 
+test("flow-style identity fanges: mode: provider på én linje er fortsatt feil", () => {
+  const yaml = "        - identity: {mode: provider, name: x}\n";
+  assert.deepEqual(identityMode(yaml), { kind: "provider", line: 1 });
+  assert.equal(identityProblem(yaml, "/x/agent.yaml")?.level, "error");
+});
+
+test("flow-style med explicit godtas, uleselig flow-style gir advarsel", () => {
+  assert.equal(identityMode('identity: {mode: "explicit", name: "B"}').kind, "explicit");
+
+  const odd = identityMode("identity: &anchor\nsomething: else");
+  assert.deepEqual(odd, { kind: "unreadable", line: 1 });
+  const problem = identityProblem("identity: &anchor\nsomething: else", "/x/agent.yaml");
+  assert.equal(problem?.level, "warn");
+  assert.match(problem!.message, /ikke kan verifisere/);
+});
+
 test("identityProblem: provider er feil, manglende identitet er en advarsel", () => {
   const provider = identityProblem("identity:\n  mode: provider\n", "/x/agent.yaml");
   assert.equal(provider?.level, "error");

--- a/apps/nvt-bridge/src/nvt/agentConfig.test.ts
+++ b/apps/nvt-bridge/src/nvt/agentConfig.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  identityMode,
+  identityProblem,
+  renderAgentConfig,
+  type AgentConfigVars,
+} from "./agentConfig.ts";
+
+const vars: AgentConfigVars = {
+  agentType: "claude",
+  runtimeArgs: ["--dangerously-skip-permissions"],
+  userMode: "non-root",
+  gitProvider: "fatdev-broker",
+  brokerProvider: "fatdev-pat",
+  targetMatch: "github.com/digdir/*",
+  urlMatch: "https://github.com/digdir/",
+  identityName: "Digdir Automation",
+  identityEmail: "bot@example.invalid",
+};
+
+test("malen setter identity.mode: explicit, aldri provider (M0-funn 4)", () => {
+  const yaml = renderAgentConfig(vars);
+  assert.equal(identityMode(yaml).kind, "explicit");
+  // Ingen aktiv mode-linje med provider (kommentaren som forklarer hvorfor
+  // ikke, skal derimot stå der).
+  assert.doesNotMatch(yaml, /^\s*mode: provider/m);
+  assert.match(yaml, /name: "Digdir Automation"/);
+  assert.match(yaml, /email: "bot@example\.invalid"/);
+});
+
+test("malen setter non-root og bypass-flagget (M0-funn 1)", () => {
+  const yaml = renderAgentConfig(vars);
+  assert.match(yaml, /user: "non-root"/);
+  assert.match(yaml, /- "--dangerously-skip-permissions"/);
+});
+
+test("tom argumentliste blir en tom YAML-liste, ikke en tom node", () => {
+  const yaml = renderAgentConfig({ ...vars, runtimeArgs: [] });
+  assert.match(yaml, /^ {2}args: \[\]$/m);
+});
+
+test("broker-provideren og match-reglene kommer fra config", () => {
+  const yaml = renderAgentConfig({ ...vars, brokerProvider: "annen-pat" });
+  assert.match(yaml, /type: broker/);
+  assert.match(yaml, /broker-provider: "annen-pat"/);
+  assert.match(yaml, /- "github\.com\/digdir\/\*"/);
+});
+
+test("verdier fra env kan ikke bryte ut av sin egen YAML-node", () => {
+  const yaml = renderAgentConfig({
+    ...vars,
+    identityName: 'Bot" \nplugins: []\n#',
+  });
+  // Alt havner i én double-quoted skalar; ingen ny toppnøkkel oppstår.
+  assert.equal(yaml.match(/^plugins:/gm)?.length, 1);
+  assert.match(yaml, /name: "Bot\\" \\nplugins: \[\]\\n#"/);
+});
+
+test("manglende identitet gir en ærlig feil, ikke en config uten identitet", () => {
+  assert.throws(() => renderAgentConfig({ ...vars, identityName: " " }), /identityName/);
+  assert.throws(() => renderAgentConfig({ ...vars, brokerProvider: "" }), /brokerProvider/);
+});
+
+test("identityMode ser bare mode: under identity:, ikke andre mode-felt", () => {
+  const yaml = [
+    "code-server:",
+    "  settings:",
+    "    overwrite: false",
+    "preseed:",
+    "  files:",
+    '    - path: "$HOME/.claude/settings.json"',
+    '      mode: "0600"',
+  ].join("\n");
+  assert.deepEqual(identityMode(yaml), { kind: "absent" });
+});
+
+test("identityMode finner provider-modus i en nøstet plugin-config", () => {
+  const yaml = [
+    "plugins:",
+    "  - name: git-credentials",
+    "    config:",
+    "      credentials:",
+    "        - match: https://github.com/digdir/",
+    "          identity:",
+    "            mode: provider",
+  ].join("\n");
+  assert.deepEqual(identityMode(yaml), { kind: "provider", line: 7 });
+});
+
+test("identityMode bryr seg ikke om kommentarer", () => {
+  const yaml = ["identity:", "  # mode: provider  <- gammelt eksempel", "  mode: explicit"].join("\n");
+  assert.equal(identityMode(yaml).kind, "explicit");
+});
+
+test("identityProblem: provider er feil, manglende identitet er en advarsel", () => {
+  const provider = identityProblem("identity:\n  mode: provider\n", "/x/agent.yaml");
+  assert.equal(provider?.level, "error");
+  assert.match(provider!.message, /M0-funn 4/);
+  assert.match(provider!.message, /\/x\/agent\.yaml/);
+
+  const absent = identityProblem("runtime:\n  command: claude\n", "/x/agent.yaml");
+  assert.equal(absent?.level, "warn");
+
+  assert.equal(identityProblem(renderAgentConfig(vars), "/x/agent.yaml"), undefined);
+});

--- a/apps/nvt-bridge/src/nvt/agentConfig.ts
+++ b/apps/nvt-bridge/src/nvt/agentConfig.ts
@@ -121,6 +121,8 @@ plugins:
 export type IdentityVerdict =
   | { kind: "explicit" }
   | { kind: "provider"; line: number }
+  /** `identity: {mode: …}` på én linje — utenfor det denne skanneren leser. */
+  | { kind: "unreadable"; line: number }
   | { kind: "absent" };
 
 /**
@@ -136,6 +138,7 @@ export function identityMode(yamlText: string): IdentityVerdict {
   const lines = yamlText.split("\n");
   let identityIndent: number | null = null;
   let sawExplicit = false;
+  let unreadableLine: number | null = null;
 
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i]!;
@@ -148,7 +151,17 @@ export function identityMode(yamlText: string): IdentityVerdict {
       // Blokka er slutt (samme eller lavere nivå enn `identity:` selv).
       identityIndent = null;
     }
-    if (/^identity:\s*$/.test(content)) {
+    const inline = /^-?\s*identity:\s*(\S.*)$/.exec(content);
+    if (inline) {
+      // Flow-style (`identity: {mode: provider}`). Vi leser mode-en når den er
+      // åpenbar, og flagger ellers at fila ikke kan verifiseres — heller det
+      // enn å svare «ingen identitet» om en config som har en.
+      if (/\bmode:\s*["']?provider\b/.test(inline[1]!)) return { kind: "provider", line: i + 1 };
+      if (/\bmode:\s*["']?explicit\b/.test(inline[1]!)) sawExplicit = true;
+      else unreadableLine ??= i + 1;
+      continue;
+    }
+    if (/^-?\s*identity:\s*$/.test(content)) {
       identityIndent = indent;
       continue;
     }
@@ -160,7 +173,9 @@ export function identityMode(yamlText: string): IdentityVerdict {
     if (value === "provider") return { kind: "provider", line: i + 1 };
     if (value === "explicit") sawExplicit = true;
   }
-  return sawExplicit ? { kind: "explicit" } : { kind: "absent" };
+  if (sawExplicit) return { kind: "explicit" };
+  if (unreadableLine !== null) return { kind: "unreadable", line: unreadableLine };
+  return { kind: "absent" };
 }
 
 /**
@@ -183,6 +198,15 @@ export function identityProblem(
         `broker-token/static_token-providere (M0-funn 4) — agenten ender uten commit-identitet og ` +
         `'git commit' feiler etter at jobben er gjort. Sett 'mode: explicit' med navn og e-post ` +
         `for bot-kontoen.`,
+    };
+  }
+  if (verdict.kind === "unreadable") {
+    return {
+      level: "warn",
+      message:
+        `${configPath} har en 'identity'-blokk på én linje (linje ${verdict.line}) som broen ikke ` +
+        `kan verifisere. Kontrollér selv at den er 'mode: explicit' med navn og e-post — ` +
+        `'mode: provider' virker ikke for broker-token (M0-funn 4).`,
     };
   }
   return {

--- a/apps/nvt-bridge/src/nvt/agentConfig.ts
+++ b/apps/nvt-bridge/src/nvt/agentConfig.ts
@@ -1,0 +1,208 @@
+/**
+ * `.agents/<navn>/agent.yaml` — instanskonfigurasjonen nvt leser.
+ *
+ * Hvorfor broen genererer den i stedet for å la `agent-init` gjøre det:
+ * nvt-malen kommer med `plugins: []` og et *kommentert* eksempel som bruker
+ * `identity.mode: provider`. Det er nøyaktig det som ikke virker for oss
+ * (M0-funn 4): `static_token`/broker-token-providere kan ikke rapportere
+ * commit-identitet, så identiteten må stå eksplisitt i configen. Uten den
+ * feiler `git commit` inne i instansen med «Author identity unknown» — etter
+ * at agenten har gjort hele jobben.
+ *
+ * `agent-init.sh` skriver bare malen når fila ikke finnes fra før (den
+ * synkroniserer `runtime.user` og sine egne markør-eide blokker på nytt-kjør).
+ * Derfor legger broen fila på plass *før* init, og rører aldri en config som
+ * allerede finnes — et menneske kan ha justert den i en levende sesjon.
+ *
+ * Bot-navn og e-post kommer fra env, aldri fra repoet (jf. planen:
+ * «botnavnet holdes utenfor repoet»).
+ */
+
+export interface AgentConfigVars {
+  /** `runtime.command` — `claude` eller `codex`. */
+  agentType: string;
+  /** Argumentene nvt gir CLI-en. Tom liste for `interactive`. */
+  runtimeArgs: string[];
+  /** `root` | `non-root`. Skal være `non-root` (M0-funn 1). */
+  userMode: string;
+  /** Providernavnet inne i instansen (fritt valgt). */
+  gitProvider: string;
+  /** Navnet på providerens grant i brokeren (`.broker/agents.yaml`). */
+  brokerProvider: string;
+  /** Glob mot normalisert repo-target, f.eks. `github.com/digdir/*`. */
+  targetMatch: string;
+  /** URL-prefiks for credential-regelen, f.eks. `https://github.com/digdir/`. */
+  urlMatch: string;
+  /** Commit-identitet — bot-kontoen. Fra env, ikke fra repoet. */
+  identityName: string;
+  identityEmail: string;
+}
+
+/**
+ * Rendrer configen. Alle verdier skrives som YAML-strenger via `JSON.stringify`
+ * (gyldig YAML double-quoted scalar), så en env-verdi med kolon, `#` eller
+ * linjeskift kan ikke bryte ut av sin egen node.
+ */
+export function renderAgentConfig(vars: AgentConfigVars): string {
+  requireNonEmpty(vars, [
+    "agentType",
+    "userMode",
+    "gitProvider",
+    "brokerProvider",
+    "targetMatch",
+    "urlMatch",
+    "identityName",
+    "identityEmail",
+  ]);
+
+  const args =
+    vars.runtimeArgs.length === 0
+      ? " []"
+      : `\n${vars.runtimeArgs.map((a) => `    - ${q(a)}`).join("\n")}`;
+
+  return `# Generert av nvt-bridge (apps/nvt-bridge/src/nvt/agentConfig.ts).
+# Kalibrert mot M0-funnene i doc/plans/nvt-agent-integrasjon.md.
+#
+# Broen skriver denne fila EN gang, før 'agent-init'. Rediger den fritt
+# etterpå — broen overskriver aldri en eksisterende config. Ett krav
+# håndheves ved hver oppstart: identity.mode må være 'explicit'.
+runtime:
+  command: ${q(vars.agentType)}
+  args:${args}
+  # M0-funn 1: claude nekter --dangerously-skip-permissions som root, og
+  # tmux-sesjonen dør innen 5 s. Agenten MÅ kjøre som 1000:1000.
+  user: ${q(vars.userMode)}
+
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+
+code-server:
+  extensions: []
+  settings:
+    overwrite: false
+    values: {}
+
+expose:
+  http: []
+
+plugins:
+  # Tokenet bor i brokeren (static_token-provider), ikke i instansens env.
+  - name: git-host-credentials
+    source: builtin
+    config:
+      default-provider: ${q(vars.gitProvider)}
+      providers:
+        - name: ${q(vars.gitProvider)}
+          type: broker
+          broker-provider: ${q(vars.brokerProvider)}
+          match:
+            - ${q(vars.targetMatch)}
+
+  - name: git-credentials
+    source: builtin
+    when: before-agent
+    config:
+      credentials:
+        - match: ${q(vars.urlMatch)}
+          provider: ${q(vars.gitProvider)}
+          # M0-funn 4: 'mode: provider' virker BARE for providere som kan
+          # rapportere identitet (GitHub App). Med broker-token må navn og
+          # e-post stå her, ellers har agenten ingen commit-identitet.
+          identity:
+            mode: explicit
+            name: ${q(vars.identityName)}
+            email: ${q(vars.identityEmail)}
+`;
+}
+
+export type IdentityVerdict =
+  | { kind: "explicit" }
+  | { kind: "provider"; line: number }
+  | { kind: "absent" };
+
+/**
+ * Leser identitetsmodusen ut av en eksisterende `agent.yaml`.
+ *
+ * Bevisst en liten skanner og ikke en YAML-parser: broen har null
+ * runtime-avhengigheter, og spørsmålet er smalt nok. Vi leter etter
+ * `mode:`-linjer som ligger ett nivå under en `identity:`-linje — ikke etter
+ * `mode:` hvor som helst i fila (`code-server.settings.overwrite` og
+ * `preseed.files[].mode` finnes også).
+ */
+export function identityMode(yamlText: string): IdentityVerdict {
+  const lines = yamlText.split("\n");
+  let identityIndent: number | null = null;
+  let sawExplicit = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    const withoutComment = raw.replace(/#.*$/, "");
+    if (withoutComment.trim() === "") continue;
+    const indent = withoutComment.length - withoutComment.trimStart().length;
+    const content = withoutComment.trim();
+
+    if (identityIndent !== null && indent <= identityIndent) {
+      // Blokka er slutt (samme eller lavere nivå enn `identity:` selv).
+      identityIndent = null;
+    }
+    if (/^identity:\s*$/.test(content)) {
+      identityIndent = indent;
+      continue;
+    }
+    if (identityIndent === null) continue;
+
+    const mode = /^-?\s*mode:\s*(\S+)\s*$/.exec(content);
+    if (!mode) continue;
+    const value = mode[1]!.replace(/^["']|["']$/g, "");
+    if (value === "provider") return { kind: "provider", line: i + 1 };
+    if (value === "explicit") sawExplicit = true;
+  }
+  return sawExplicit ? { kind: "explicit" } : { kind: "absent" };
+}
+
+/**
+ * Kaster hvis en eksisterende config har `identity.mode: provider`, og
+ * returnerer en advarsel når identiteten mangler helt. Vi retter ikke fila
+ * selv — den kan være håndredigert, og en stille omskriving er verre enn en
+ * ærlig feil.
+ */
+export function identityProblem(
+  yamlText: string,
+  configPath: string,
+): { level: "error" | "warn"; message: string } | undefined {
+  const verdict = identityMode(yamlText);
+  if (verdict.kind === "explicit") return undefined;
+  if (verdict.kind === "provider") {
+    return {
+      level: "error",
+      message:
+        `${configPath} har 'identity.mode: provider' (linje ${verdict.line}). Det støttes ikke av ` +
+        `broker-token/static_token-providere (M0-funn 4) — agenten ender uten commit-identitet og ` +
+        `'git commit' feiler etter at jobben er gjort. Sett 'mode: explicit' med navn og e-post ` +
+        `for bot-kontoen.`,
+    };
+  }
+  return {
+    level: "warn",
+    message:
+      `${configPath} har ingen 'identity'-blokk under git-credentials. Er ikke commit-identiteten ` +
+      `satt et annet sted, feiler 'git commit' inne i instansen (M0-funn 4).`,
+  };
+}
+
+function q(value: string): string {
+  return JSON.stringify(value);
+}
+
+function requireNonEmpty(vars: AgentConfigVars, keys: (keyof AgentConfigVars)[]): void {
+  const missing = keys.filter((k) => String(vars[k] ?? "").trim() === "");
+  if (missing.length > 0) {
+    throw new Error(
+      `agent.yaml kan ikke genereres: mangler ${missing.join(", ")}. ` +
+        `Commit-identitet og provider-navn må settes i .env (se .env.example).`,
+    );
+  }
+}

--- a/apps/nvt-bridge/src/nvt/docker.test.ts
+++ b/apps/nvt-bridge/src/nvt/docker.test.ts
@@ -1,12 +1,99 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { DockerNvtDriver, isDoneEvent, type ExecFn } from "./docker.ts";
+import { identityMode } from "./agentConfig.ts";
+import {
+  DockerNvtDriver,
+  isDoneEvent,
+  runtimeArgsFor,
+  type ExecFn,
+  type FsFns,
+} from "./docker.ts";
 
 /**
- * Adapteren er uverifisert mot en ekte instans (kalibreres mot M0-funn), så
- * testene her dekker bare det som er ren logikk: kommandoene som bygges og
- * gjenkjenningen av done-eventet.
+ * Adapteren er kalibrert mot M0-funnene, men fortsatt ikke prøvd mot en ekte
+ * instans. Testene dekker derfor det som er ren logikk: kommandoene som bygges,
+ * klar-sjekkens tilstandsmaskin, `agent.yaml`-håndteringen og gjenkjenningen av
+ * done-eventet.
  */
+
+interface Recorded {
+  cmd: string;
+  args: string[];
+  cwd?: string;
+}
+
+interface ExecOptions {
+  /** Svar fra `docker inspect` — er instansen oppe? */
+  running?: boolean;
+  /** Finnes `session-launched`-markøren? */
+  marker?: boolean;
+  /** Panelinnhold per `capture-pane`. Siste verdi gjentas. */
+  panes?: string[];
+  /** `capture-pane` feiler (ingen tmux-sesjon). */
+  paneFails?: boolean;
+}
+
+function recordingExec(opts: ExecOptions = {}): { exec: ExecFn; calls: Recorded[] } {
+  const calls: Recorded[] = [];
+  const panes = [...(opts.panes ?? ["? for shortcuts"])];
+  const exec: ExecFn = async (cmd, args, execOpts) => {
+    calls.push({ cmd, args, cwd: execOpts.cwd });
+    if (cmd === "docker" && args[0] === "inspect") {
+      return opts.running
+        ? { code: 0, stdout: "true\n", stderr: "" }
+        : { code: 1, stdout: "", stderr: "" };
+    }
+    if (args.includes("capture-pane")) {
+      if (opts.paneFails) return { code: 1, stdout: "", stderr: "no server running\n" };
+      const text = panes.length > 1 ? panes.shift()! : (panes[0] ?? "");
+      return { code: 0, stdout: text, stderr: "" };
+    }
+    if (args.includes("sh") && args.some((a) => a.includes("session-launched"))) {
+      return { code: opts.marker === false ? 1 : 0, stdout: "", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  return { exec, calls };
+}
+
+function memoryFs(initial: Record<string, string> = {}): FsFns & { files: Map<string, string> } {
+  const files = new Map(Object.entries(initial));
+  return {
+    files,
+    readFile: async (target) => files.get(target) ?? null,
+    writeFile: async (target, content) => {
+      files.set(target, content);
+    },
+    mkdirp: async () => {},
+  };
+}
+
+const identity = {
+  gitProvider: "fatdev-broker",
+  brokerProvider: "fatdev-pat",
+  targetMatch: "github.com/digdir/*",
+  urlMatch: "https://github.com/digdir/",
+  identityName: "Test Bot",
+  identityEmail: "bot@example.invalid",
+};
+
+function driverWith(
+  execOpts: ExecOptions = {},
+  overrides: Partial<ConstructorParameters<typeof DockerNvtDriver>[0]> = {},
+) {
+  const { exec, calls } = recordingExec(execOpts);
+  const fs = memoryFs();
+  const driver = new DockerNvtDriver({
+    nvtRoot: "/srv/nvt",
+    agentType: "claude",
+    agentConfig: identity,
+    exec,
+    fs,
+    sleep: async () => {},
+    ...overrides,
+  });
+  return { driver, calls, fs };
+}
 
 test("isDoneEvent gjenkjenner plugin.agent.signal.done på begge feltnavn", () => {
   assert.equal(isDoneEvent('{"type":"plugin.agent.signal.done"}'), true);
@@ -25,35 +112,256 @@ test("isDoneEvent ignorerer andre events, støy og ugyldig JSON", () => {
   assert.equal(isDoneEvent('["type","plugin.agent.signal.done"]'), false);
 });
 
-function recordingExec(): { exec: ExecFn; calls: { cmd: string; args: string[]; cwd?: string }[] } {
-  const calls: { cmd: string; args: string[]; cwd?: string }[] = [];
-  const exec: ExecFn = async (cmd, args, opts) => {
-    calls.push({ cmd, args, cwd: opts.cwd });
-    // `docker inspect` → instansen er ikke oppe.
-    if (cmd === "docker" && args[0] === "inspect") return { code: 1, stdout: "", stderr: "" };
-    return { code: 0, stdout: "", stderr: "" };
-  };
-  return { exec, calls };
-}
+// --- agent-init: --user non-root (M0-funn 1) ---------------------------------
 
-test("ensureInstance kjører agent-init og agent-up i nvt-sjekkouten", async () => {
-  const { exec, calls } = recordingExec();
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude", exec });
+test("agent-init kjøres som script med --user non-root, ikke via make", async () => {
+  const { driver, calls } = driverWith();
   await driver.ensureInstance("topic-1", "fatdev-x-1234abcd");
 
-  const makeCalls = calls.filter((c) => c.cmd === "make");
-  assert.deepEqual(makeCalls[0]!.args, [
-    "agent-init",
-    "NAME=fatdev-x-1234abcd",
-    "TYPE=claude",
+  const init = calls.find((c) => c.args.some((a) => a.includes("agent-init")));
+  assert.ok(init, "agent-init må kjøres");
+  assert.equal(init.cmd, "bash", "make agent-init forwarder ikke --user");
+  assert.deepEqual(init.args, [
+    "scripts/agent-init.sh",
+    "--name",
+    "fatdev-x-1234abcd",
+    "--type",
+    "claude",
+    "--autonomy",
+    "trusted-local",
+    "--user",
+    "non-root",
   ]);
-  assert.deepEqual(makeCalls[1]!.args, ["agent-up", "NAME=fatdev-x-1234abcd"]);
-  assert.equal(makeCalls[0]!.cwd, "/srv/nvt", "make må kjøres fra NVT_ROOT");
+  assert.equal(init.cwd, "/srv/nvt", "init må kjøres fra NVT_ROOT");
+
+  const up = calls.find((c) => c.cmd === "make");
+  assert.deepEqual(up?.args, ["agent-up", "NAME=fatdev-x-1234abcd"]);
+  assert.equal(up?.cwd, "/srv/nvt");
 });
 
+test("userMode kan overstyres, men non-root er default", async () => {
+  const { driver, calls } = driverWith({}, { userMode: "root" });
+  await driver.ensureInstance("t", "i");
+  const init = calls.find((c) => c.cmd === "bash")!;
+  assert.equal(init.args.at(-1), "root");
+});
+
+test("en levende instans re-initialiseres ikke", async () => {
+  const { driver, calls } = driverWith({ running: true });
+  await driver.ensureInstance("t", "i");
+  assert.equal(
+    calls.some((c) => c.cmd === "make" || c.cmd === "bash"),
+    false,
+    "ingen init/up når instansen er oppe",
+  );
+});
+
+test("feilende agent-init kaster med kommandoen i meldingen", async () => {
+  const exec: ExecFn = async (cmd, args) => {
+    if (cmd === "docker" && args[0] === "inspect") return { code: 1, stdout: "", stderr: "" };
+    if (cmd === "bash") return { code: 2, stdout: "", stderr: "invalid user: nonroot\n" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const { driver } = driverWith({}, { exec });
+  await assert.rejects(() => driver.ensureInstance("t", "i"), /agent-init\.sh.*invalid user/s);
+});
+
+// --- agent.yaml: identity.mode explicit (M0-funn 4) --------------------------
+
+test("agent.yaml skrives før init, med eksplisitt commit-identitet", async () => {
+  const { driver, calls, fs } = driverWith();
+  await driver.ensureInstance("t", "fatdev-y");
+
+  const written = fs.files.get("/srv/nvt/.agents/fatdev-y/agent.yaml");
+  assert.ok(written, "configen må ligge der før agent-init");
+  assert.equal(identityMode(written).kind, "explicit");
+  assert.match(written, /name: "Test Bot"/);
+  assert.match(written, /broker-provider: "fatdev-pat"/);
+  assert.match(written, /user: "non-root"/);
+  assert.match(written, /--dangerously-skip-permissions/);
+
+  // Rekkefølgen er poenget: agent-init skriver nvt-malen hvis fila mangler.
+  const initIndex = calls.findIndex((c) => c.cmd === "bash");
+  assert.ok(initIndex >= 0);
+});
+
+test("en eksisterende agent.yaml overskrives ikke", async () => {
+  const { exec } = recordingExec();
+  const fs = memoryFs({
+    "/srv/nvt/.agents/i/agent.yaml": "runtime:\n  command: claude\nidentity:\n  mode: explicit\n",
+  });
+  const driver = new DockerNvtDriver({
+    nvtRoot: "/srv/nvt",
+    agentType: "claude",
+    agentConfig: identity,
+    exec,
+    fs,
+    sleep: async () => {},
+  });
+  await driver.ensureInstance("t", "i");
+  assert.match(fs.files.get("/srv/nvt/.agents/i/agent.yaml")!, /^runtime:\n {2}command: claude/);
+});
+
+test("identity.mode: provider i eksisterende config stopper oppstart (M0-funn 4)", async () => {
+  const { exec } = recordingExec();
+  const fs = memoryFs({
+    "/srv/nvt/.agents/i/agent.yaml":
+      "plugins:\n  - name: git-credentials\n    config:\n      credentials:\n" +
+      "        - match: https://github.com/digdir/\n          identity:\n            mode: provider\n",
+  });
+  const driver = new DockerNvtDriver({
+    nvtRoot: "/srv/nvt",
+    agentType: "claude",
+    agentConfig: identity,
+    exec,
+    fs,
+    sleep: async () => {},
+  });
+  await assert.rejects(
+    () => driver.ensureInstance("t", "i"),
+    /identity\.mode: provider.*static_token/s,
+  );
+});
+
+test("manglende identitet i configen kan ikke genereres bort i stillhet", async () => {
+  const { exec } = recordingExec();
+  const driver = new DockerNvtDriver({
+    nvtRoot: "/srv/nvt",
+    agentType: "claude",
+    agentConfig: { ...identity, identityEmail: "" },
+    exec,
+    fs: memoryFs(),
+    sleep: async () => {},
+  });
+  await assert.rejects(() => driver.ensureInstance("t", "i"), /identityEmail/);
+});
+
+test("runtimeArgsFor følger agent-init.sh sin utledning", () => {
+  assert.deepEqual(runtimeArgsFor("claude", "trusted-local"), ["--dangerously-skip-permissions"]);
+  assert.deepEqual(runtimeArgsFor("claude", "interactive"), []);
+  assert.deepEqual(runtimeArgsFor("codex", "trusted-local"), [
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
+  ]);
+  assert.throws(() => runtimeArgsFor("gemini", "trusted-local"), /ukjent agent-type/);
+});
+
+// --- klar-sjekk før prompt (M0-funn 5) --------------------------------------
+
+test("waitUntilReady godtar sesjonen når panelet viser klar-prompt", async () => {
+  const { driver, calls } = driverWith({ panes: ["? for shortcuts"] });
+  await driver.waitUntilReady({ topic: "t", instance: "i" }, { timeoutMs: 1000 });
+
+  assert.equal(
+    calls.some((c) => c.args.includes("send-keys")),
+    false,
+    "Enter skal ALDRI sendes i blinde — bare når en dialog faktisk står der",
+  );
+  assert.ok(
+    calls.some((c) => c.args.some((a) => a.includes("session-launched"))),
+    "markøren må sjekkes",
+  );
+});
+
+test("waitUntilReady sender Enter gjennom onboarding-dialogen og fortsetter", async () => {
+  const { driver, calls } = driverWith({
+    panes: ["Do you trust the files in this folder?", "? for shortcuts"],
+  });
+  await driver.waitUntilReady({ topic: "t", instance: "i" }, { timeoutMs: 1000 });
+
+  const enters = calls.filter((c) => c.args.includes("send-keys"));
+  assert.equal(enters.length, 1);
+  assert.deepEqual(enters[0]!.args, [
+    "exec",
+    "agent-i-agent-1",
+    "tmux",
+    "send-keys",
+    "-t",
+    "agent",
+    "Enter",
+  ]);
+});
+
+test("waitUntilReady kaster når markøren mangler — ingen prompt sendes", async () => {
+  const { driver } = driverWith({ marker: false });
+  await assert.rejects(
+    () => driver.waitUntilReady({ topic: "t", instance: "i" }, { timeoutMs: 1 }),
+    /ble ikke klar.*session-launched-markør: nei/s,
+  );
+});
+
+test("waitUntilReady kaster når tmux-sesjonen ikke svarer", async () => {
+  const { driver } = driverWith({ paneFails: true });
+  await assert.rejects(
+    () => driver.waitUntilReady({ topic: "t", instance: "i" }, { timeoutMs: 1 }),
+    /tmux-sesjon «agent»: nei/,
+  );
+});
+
+test("feilmeldingen gjengir aldri panelinnholdet (kan inneholde hva som helst)", async () => {
+  const { driver } = driverWith({ panes: ["ANTHROPIC_AUTH_TOKEN=hemmelig-verdi"] });
+  await assert.rejects(
+    () => driver.waitUntilReady({ topic: "t", instance: "i" }, { timeoutMs: 1 }),
+    (err: Error) => {
+      assert.doesNotMatch(err.message, /hemmelig-verdi/);
+      assert.match(err.message, /panel: unknown/);
+      return true;
+    },
+  );
+});
+
+test("Enter-budsjettet er begrenset — en dialog som ikke gir seg ender i ærlig feil", async () => {
+  const { driver, calls } = driverWith(
+    { panes: ["Press Enter to continue"] },
+    { maxEnterPresses: 2 },
+  );
+  await assert.rejects(
+    () => driver.waitUntilReady({ topic: "t", instance: "i" }, { timeoutMs: 5 }),
+    /ble ikke klar.*panel: onboarding/s,
+  );
+  assert.ok(
+    calls.filter((c) => c.args.includes("send-keys")).length <= 2,
+    "aldri mer enn budsjettet",
+  );
+});
+
+test("waitUntilReady respekterer abort (broen avslutter)", async () => {
+  const { driver } = driverWith({ marker: false });
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    () => driver.waitUntilReady({ topic: "t", instance: "i" }, { timeoutMs: 1000, signal: controller.signal }),
+    /avbrutt/,
+  );
+});
+
+test("etter bekreftet klar-tilstand godtas «lever, men ingen klar-prompt» (agenten kan jobbe)", async () => {
+  const { driver } = driverWith({ panes: ["? for shortcuts", "kompilerer …"] });
+  const ref = { topic: "t", instance: "i" };
+  await driver.waitUntilReady(ref, { timeoutMs: 1000 });
+  // Panelet viser nå arbeid, ikke klar-prompt. Sesjonen lever og ingen dialog
+  // står i veien, så agentd køer prompten selv.
+  await driver.waitUntilReady(ref, { timeoutMs: 1 });
+});
+
+test("en dialog etter bekreftet klar-tilstand godtas IKKE", async () => {
+  const { driver } = driverWith({
+    panes: ["? for shortcuts", "Do you trust the files in this folder?"],
+  });
+  const ref = { topic: "t", instance: "i" };
+  await driver.waitUntilReady(ref, { timeoutMs: 1000 });
+  await assert.rejects(
+    () => driver.waitUntilReady(ref, { timeoutMs: 1 }),
+    /panel: onboarding/,
+  );
+});
+
+// --- prompt og opprydding ---------------------------------------------------
+
 test("sendPrompt sender alltid --external (upålitelig input)", async () => {
-  const { exec, calls } = recordingExec();
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude", exec });
+  const { driver, calls } = driverWith();
   await driver.sendPrompt({ topic: "t", instance: "fatdev-x-1234abcd" }, "oppgave");
 
   const call = calls.find((c) => c.args.includes("agentdctl"))!;
@@ -70,8 +378,7 @@ test("sendPrompt sender alltid --external (upålitelig input)", async () => {
 });
 
 test("prompten sendes som ett argv-element — ingen shell-tolkning", async () => {
-  const { exec, calls } = recordingExec();
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude", exec });
+  const { driver, calls } = driverWith();
   const nasty = 'x"; rm -rf / #\n$(whoami) `id` && echo pwned';
   await driver.sendPrompt({ topic: "t", instance: "i" }, nasty);
   const call = calls.find((c) => c.args.includes("agentdctl"))!;
@@ -81,42 +388,28 @@ test("prompten sendes som ett argv-element — ingen shell-tolkning", async () =
 
 test("feilende agentdctl kaster (broen skriver da en error-linje)", async () => {
   const exec: ExecFn = async () => ({ code: 3, stdout: "", stderr: "no such container\n" });
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude", exec });
+  const { driver } = driverWith({}, { exec });
   await assert.rejects(
     () => driver.sendPrompt({ topic: "t", instance: "i" }, "x"),
     /agentdctl prompt feilet.*no such container/s,
   );
 });
 
-test("feilende make kaster med målet i meldingen", async () => {
-  const exec: ExecFn = async (cmd) =>
-    cmd === "make"
-      ? { code: 2, stdout: "", stderr: "No rule to make target 'agent-init'\n" }
-      : { code: 1, stdout: "", stderr: "" };
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude", exec });
-  await assert.rejects(() => driver.ensureInstance("t", "i"), /make agent-init.*No rule/s);
-});
-
 test("stopInstance kjører agent-down (workspacet beholdes)", async () => {
-  const { exec, calls } = recordingExec();
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude", exec });
+  const { driver, calls } = driverWith();
   await driver.stopInstance({ topic: "t", instance: "fatdev-x-1234abcd" });
   assert.deepEqual(calls.at(-1)!.args, ["agent-down", "NAME=fatdev-x-1234abcd"]);
 });
 
-test("containernavnet følger compose-mønsteret fra planen", () => {
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude" });
-  assert.equal(driver.containerName("fatdev-x-1234abcd"), "agent-fatdev-x-1234abcd-agent-1");
+test("stopInstance nullstiller klar-tilstanden (ny sesjon = ny onboarding)", async () => {
+  const { driver } = driverWith({ panes: ["? for shortcuts", "kompilerer …"] });
+  const ref = { topic: "t", instance: "i" };
+  await driver.waitUntilReady(ref, { timeoutMs: 1000 });
+  await driver.stopInstance(ref);
+  await assert.rejects(() => driver.waitUntilReady(ref, { timeoutMs: 1 }), /ble ikke klar/);
 });
 
-test("en levende instans re-initialiseres ikke", async () => {
-  const calls: string[][] = [];
-  const exec: ExecFn = async (cmd, args) => {
-    calls.push([cmd, ...args]);
-    if (cmd === "docker" && args[0] === "inspect") return { code: 0, stdout: "true\n", stderr: "" };
-    return { code: 0, stdout: "", stderr: "" };
-  };
-  const driver = new DockerNvtDriver({ nvtRoot: "/srv/nvt", agentType: "claude", exec });
-  await driver.ensureInstance("t", "i");
-  assert.equal(calls.some((c) => c[0] === "make"), false, "ingen make når instansen er oppe");
+test("containernavnet følger compose-mønsteret fra planen", () => {
+  const { driver } = driverWith();
+  assert.equal(driver.containerName("fatdev-x-1234abcd"), "agent-fatdev-x-1234abcd-agent-1");
 });

--- a/apps/nvt-bridge/src/nvt/docker.test.ts
+++ b/apps/nvt-bridge/src/nvt/docker.test.ts
@@ -23,7 +23,7 @@ interface Recorded {
 }
 
 interface ExecOptions {
-  /** Svar fra `docker inspect` — er instansen oppe? */
+  /** Svar fra `docker inspect -f {{.State.Running}}` — er instansen oppe? */
   running?: boolean;
   /** Finnes `session-launched`-markøren? */
   marker?: boolean;
@@ -31,14 +31,25 @@ interface ExecOptions {
   panes?: string[];
   /** `capture-pane` feiler (ingen tmux-sesjon). */
   paneFails?: boolean;
+  /** `tmux has-session` feiler (brukes når panelet ikke leses). */
+  sessionGone?: boolean;
+  /** Container-inkarnasjon per oppslag. Siste verdi gjentas — endres den, er containeren restartet. */
+  incarnations?: string[];
 }
 
 function recordingExec(opts: ExecOptions = {}): { exec: ExecFn; calls: Recorded[] } {
   const calls: Recorded[] = [];
   const panes = [...(opts.panes ?? ["? for shortcuts"])];
+  const incarnations = [...(opts.incarnations ?? ["sha256:abc 2026-07-31T10:00:00Z"])];
   const exec: ExecFn = async (cmd, args, execOpts) => {
     calls.push({ cmd, args, cwd: execOpts.cwd });
     if (cmd === "docker" && args[0] === "inspect") {
+      if (args.some((a) => a.includes("{{.Id}}"))) {
+        const value = incarnations.length > 1 ? incarnations.shift()! : (incarnations[0] ?? "");
+        return value === ""
+          ? { code: 1, stdout: "", stderr: "No such object\n" }
+          : { code: 0, stdout: `${value}\n`, stderr: "" };
+      }
       return opts.running
         ? { code: 0, stdout: "true\n", stderr: "" }
         : { code: 1, stdout: "", stderr: "" };
@@ -47,6 +58,11 @@ function recordingExec(opts: ExecOptions = {}): { exec: ExecFn; calls: Recorded[
       if (opts.paneFails) return { code: 1, stdout: "", stderr: "no server running\n" };
       const text = panes.length > 1 ? panes.shift()! : (panes[0] ?? "");
       return { code: 0, stdout: text, stderr: "" };
+    }
+    if (args.includes("has-session")) {
+      return opts.sessionGone
+        ? { code: 1, stdout: "", stderr: "can't find session\n" }
+        : { code: 0, stdout: "", stderr: "" };
     }
     if (args.includes("sh") && args.some((a) => a.includes("session-launched"))) {
       return { code: opts.marker === false ? 1 : 0, stdout: "", stderr: "" };
@@ -80,7 +96,12 @@ const identity = {
 function driverWith(
   execOpts: ExecOptions = {},
   overrides: Partial<ConstructorParameters<typeof DockerNvtDriver>[0]> = {},
-) {
+): {
+  driver: DockerNvtDriver;
+  calls: Recorded[];
+  fs: FsFns & { files: Map<string, string> };
+  execOpts: ExecOptions;
+} {
   const { exec, calls } = recordingExec(execOpts);
   const fs = memoryFs();
   const driver = new DockerNvtDriver({
@@ -92,7 +113,9 @@ function driverWith(
     sleep: async () => {},
     ...overrides,
   });
-  return { driver, calls, fs };
+  // `execOpts` leses ved hvert kall, så en test kan endre tilstanden underveis
+  // (sesjonen dør, containeren restartes).
+  return { driver, calls, fs, execOpts };
 }
 
 test("isDoneEvent gjenkjenner plugin.agent.signal.done på begge feltnavn", () => {
@@ -337,25 +360,74 @@ test("waitUntilReady respekterer abort (broen avslutter)", async () => {
   );
 });
 
-test("etter bekreftet klar-tilstand godtas «lever, men ingen klar-prompt» (agenten kan jobbe)", async () => {
-  const { driver } = driverWith({ panes: ["? for shortcuts", "kompilerer …"] });
+test("etter bekreftet klar-tilstand holder det at tmux-sesjonen lever", async () => {
+  const { driver, calls } = driverWith({ panes: ["? for shortcuts"] });
   const ref = { topic: "t", instance: "i" };
   await driver.waitUntilReady(ref, { timeoutMs: 1000 });
-  // Panelet viser nå arbeid, ikke klar-prompt. Sesjonen lever og ingen dialog
-  // står i veien, så agentd køer prompten selv.
+  const before = calls.length;
+  // Agenten kan være midt i arbeid; agentd køer prompten selv.
   await driver.waitUntilReady(ref, { timeoutMs: 1 });
+
+  const after = calls.slice(before);
+  assert.ok(
+    after.some((c) => c.args.includes("has-session")),
+    "sesjonen sjekkes fortsatt",
+  );
+  assert.equal(
+    after.some((c) => c.args.includes("capture-pane")),
+    false,
+    "panelet inneholder transkriptet (upålitelig input) og skal ikke styre gaten her",
+  );
 });
 
-test("en dialog etter bekreftet klar-tilstand godtas IKKE", async () => {
-  const { driver } = driverWith({
-    panes: ["? for shortcuts", "Do you trust the files in this folder?"],
-  });
+test("dør tmux-sesjonen etter bekreftet klar-tilstand, leveres ingenting", async () => {
+  const { driver, execOpts } = driverWith({ panes: ["? for shortcuts"] });
   const ref = { topic: "t", instance: "i" };
   await driver.waitUntilReady(ref, { timeoutMs: 1000 });
+
+  execOpts.sessionGone = true;
+  await assert.rejects(
+    () => driver.waitUntilReady(ref, { timeoutMs: 1 }),
+    /tmux-sesjon «agent»: nei/,
+  );
+});
+
+test("restartes containeren utenfor broen, gjøres klar-sjekken på nytt", async () => {
+  // Klar-tilstanden gjelder én container-inkarnasjon. `docker restart` eller en
+  // host-reboot gir ny sesjon med ny onboarding, selv om broen aldri kjørte
+  // agent-up — da må gaten være streng igjen.
+  const { driver, calls } = driverWith(
+    {
+      panes: ["? for shortcuts", "│ ✻ Welcome to Claude Code!"],
+      incarnations: ["sha256:abc 10:00:00Z", "sha256:abc 11:30:00Z"],
+    },
+    { maxEnterPresses: 0 },
+  );
+  const ref = { topic: "t", instance: "i" };
+  await driver.waitUntilReady(ref, { timeoutMs: 1000 });
+
+  const before = calls.length;
   await assert.rejects(
     () => driver.waitUntilReady(ref, { timeoutMs: 1 }),
     /panel: onboarding/,
+    "ny inkarnasjon ⇒ panelet leses igjen, og onboardingen fanges",
   );
+  assert.ok(
+    calls.slice(before).some((c) => c.args.includes("capture-pane")),
+    "streng sjekk leser panelet",
+  );
+});
+
+test("svarer docker inspect ikke, behandles sesjonen som fersk (trygg side)", async () => {
+  const { driver } = driverWith({
+    panes: ["? for shortcuts"],
+    incarnations: ["sha256:abc 10:00:00Z", ""],
+  });
+  const ref = { topic: "t", instance: "i" };
+  await driver.waitUntilReady(ref, { timeoutMs: 1000 });
+  // Uten inkarnasjon vet vi ikke om det er samme sesjon → streng sjekk, som her
+  // fortsatt viser klar-prompt.
+  await driver.waitUntilReady(ref, { timeoutMs: 1000 });
 });
 
 // --- prompt og opprydding ---------------------------------------------------

--- a/apps/nvt-bridge/src/nvt/docker.ts
+++ b/apps/nvt-bridge/src/nvt/docker.ts
@@ -1,45 +1,83 @@
 import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  identityProblem,
+  renderAgentConfig,
+  type AgentConfigVars,
+} from "./agentConfig.ts";
 import type { DoneOutcome, NvtDriver, NvtInstance } from "./driver.ts";
+import {
+  classifyPane,
+  DEFAULT_PANE_PATTERNS,
+  type PaneState,
+  type PanePatterns,
+} from "./ready.ts";
 
 /**
  * ==========================================================================
- *  KALIBRERES MOT M0-FUNN (issue #96) — ikke verifisert mot en ekte instans.
+ *  Tynn adapter over nvt-agents lokale flyt — kalibrert mot M0-funnene
+ *  (issue #96, `doc/plans/nvt-agent-integrasjon.md` § «M0-funn»).
  * ==========================================================================
  *
- * Tynn adapter over nvt-agents lokale compose-flyt. Den er bevisst så tynn
- * som mulig: alle antakelser om nvt-oppsettet bor HER, og ingen andre steder
- * i bridgen. Kjernelogikken testes mot `FakeNvtDriver` og er uavhengig av
- * hvordan denne fila ender opp.
+ * Alle antakelser om nvt-oppsettet bor HER og ingen andre steder i broen.
+ * Kjernelogikken testes mot `FakeNvtDriver` og er uavhengig av denne fila.
  *
- * Disse punktene er ubekreftet til M0 er kjørt, og er de eneste som skal
- * trenge endring etterpå:
+ * Hva M0 endret, og hvorfor:
  *
- * - **Make-målene**: `make agent-init NAME=<n> TYPE=<t>` og
- *   `make agent-up NAME=<n>` / `make agent-down NAME=<n>`, kjørt med
- *   `NVT_ROOT` som cwd. Signaturene er lest ut av planen, ikke prøvd.
- * - **Containernavnet**: planen skriver `agent-<navn>-agent-1` (compose sitt
- *   default `<prosjekt>-<tjeneste>-<n>`). Er tjenestenavnet eller
- *   prosjektprefikset noe annet, er `containerName()` det ene stedet å rette.
- * - **`agentdctl`-stien og subscribe-formatet**: vi antar `agentdctl` på PATH
- *   i runtime-containeren, at `subscribe` skriver JSONL til stdout, og at
- *   done-eventet har `type` (eller `event`) `plugin.agent.signal.done`.
- *   `isDoneEvent()` godtar begge feltnavn nettopp fordi dette er uverifisert.
- * - **Nettverk/host-oppslag** (`network_mode: service:docker`,
- *   `host.docker.internal`) berøres IKKE herfra. Det er instans-config i
- *   `.agents/<navn>/env` og hører til M0-oppsettet, ikke til bridgen.
+ * 1. **`agent-init` kjøres som script, ikke via `make`.** `make agent-init`
+ *    kaller `scripts/agent-init.sh --name --type --autonomy` og forwarder
+ *    *ikke* `--user`. Vi må ha `--user non-root` (M0-funn 1: claude nekter
+ *    `--dangerously-skip-permissions` som root, tmux-sesjonen dør innen 5 s),
+ *    så adapteren kaller scriptet direkte. `agent-up`/`agent-down` går
+ *    fortsatt gjennom make — de tar bare `NAME`.
+ * 2. **Klar-sjekk før første prompt** (M0-funn 5). Se `waitUntilReady`.
+ * 3. **`agent.yaml` legges på plass før init** (M0-funn 4) — nvt-malen har
+ *    `plugins: []`, og eksempelet der bruker `identity.mode: provider`, som
+ *    ikke virker for broker-token. Se `agentConfig.ts`.
+ * 4. **Sti-validering** (M0-funn 2) skjer ved oppstart, i `paths.ts`.
+ *
+ * Fortsatt uverifisert mot en ekte instans:
+ *
+ * - **Containernavnet**: `agent-<navn>-agent-1` (compose sitt
+ *   `<prosjekt>-<tjeneste>-<n>`). Er tjenestenavnet noe annet, er
+ *   `containerName()` det ene stedet å rette.
+ * - **`subscribe`-formatet**: vi antar JSONL på stdout og at done-eventet har
+ *   `type` (eller `event`) `plugin.agent.signal.done`. `isDoneEvent()` godtar
+ *   begge feltnavn nettopp fordi dette ikke er prøvd ende-til-ende.
+ * - **Klar-mønstrene** er claude-TUI-tekst, altså heuristikk. De kan
+ *   overstyres med env — se `ready.ts`.
+ * - **Nettverk/host-oppslag** berøres IKKE herfra (M0 bekreftet at
+ *   `host.docker.internal:8787` virker); det er instans-config i
+ *   `.agents/<navn>/env`.
  * - **Bind-mount-fella**: compose-mounts løses av *hostens* daemon, så
  *   `NVT_ROOT` og triggers-stien må være identiske inne i bridge-containeren
- *   og på hosten. Adapteren gjør ingen sti-oversetting — det er et bevisst
- *   valg, ikke en glipp.
+ *   og på hosten. Adapteren gjør ingen sti-oversetting — bevisst valg.
  */
 
 export interface DockerNvtDriverOptions {
-  /** Sjekkouten av nvt-agent — cwd for make-kallene. */
+  /** Sjekkouten av nvt-agent — cwd for `make` og `scripts/`. */
   nvtRoot: string;
   /** Agent-type til `agent-init` (f.eks. `claude`). */
   agentType: string;
+  /** `--autonomy` til `agent-init`. Default `trusted-local`. */
+  autonomy?: string;
+  /** `--user` til `agent-init`. Default (og eneste fungerende) `non-root`. */
+  userMode?: string;
+  /** tmux-sesjonen agenten kjører i (`AGENT_SESSION` i nvt). Default `agent`. */
+  tmuxSession?: string;
+  /** Identitet/provider til `agent.yaml`. Uten den kan configen ikke skrives. */
+  agentConfig: Omit<AgentConfigVars, "agentType" | "runtimeArgs" | "userMode">;
+  /** Mønstre for klar-sjekken. Default `DEFAULT_PANE_PATTERNS`. */
+  panePatterns?: PanePatterns;
+  /** Hvor tett klar-sjekken poller. Default 2000 ms. */
+  readyPollMs?: number;
+  /** Maks antall Enter gjennom onboarding-dialogene. Default 3. */
+  maxEnterPresses?: number;
   /** Overstyring for testing/tørrkjøring. */
   exec?: ExecFn;
+  fs?: FsFns;
+  sleep?: (ms: number) => Promise<void>;
   log?: (message: string) => void;
 }
 
@@ -49,25 +87,52 @@ export type ExecFn = (
   opts: { cwd?: string },
 ) => Promise<{ code: number; stdout: string; stderr: string }>;
 
+/** Det lille filsystem-snittet adapteren trenger — injiserbart for tester. */
+export interface FsFns {
+  /** `null` når fila ikke finnes. */
+  readFile(target: string): Promise<string | null>;
+  writeFile(target: string, content: string): Promise<void>;
+  mkdirp(target: string): Promise<void>;
+}
+
 export class DockerNvtDriver implements NvtDriver {
   private readonly opts: DockerNvtDriverOptions;
   private readonly exec: ExecFn;
+  private readonly fs: FsFns;
+  private readonly sleep: (ms: number) => Promise<void>;
   private readonly log: (message: string) => void;
+  private readonly patterns: PanePatterns;
+  private readonly session: string;
   /** Instanser vi har kjørt `agent-up` for i denne prosessen. */
   private readonly started = new Set<string>();
+  /**
+   * Instanser vi har sett klar-prompten i. Første prompt i en sesjon krever
+   * *positiv* klar-tilstand; senere prompts godtar «lever, ingen dialog» — da
+   * kan sesjonen være midt i arbeid, og agentd køer prompten selv.
+   */
+  private readonly readyConfirmed = new Set<string>();
 
   constructor(opts: DockerNvtDriverOptions) {
     this.opts = opts;
     this.exec = opts.exec ?? runCommand;
+    this.fs = opts.fs ?? nodeFs;
+    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
     this.log = opts.log ?? (() => {});
+    this.patterns = opts.panePatterns ?? DEFAULT_PANE_PATTERNS;
+    this.session = opts.tmuxSession ?? "agent";
   }
 
   /**
    * Compose-container for instansens runtime. Se advarselen øverst — dette
-   * navnet er det mest sannsynlige M0 må rette.
+   * navnet er det mest sannsynlige som må rettes.
    */
   containerName(instance: string): string {
     return `agent-${instance}-agent-1`;
+  }
+
+  /** `.agents/<navn>/agent.yaml` i nvt-sjekkouten. */
+  agentConfigPath(instance: string): string {
+    return path.join(this.opts.nvtRoot, ".agents", instance, "agent.yaml");
   }
 
   async ensureInstance(topic: string, instance: string): Promise<NvtInstance> {
@@ -75,17 +140,133 @@ export class DockerNvtDriver implements NvtDriver {
     if (this.started.has(instance) && (await this.isRunning(instance))) {
       return ref;
     }
-    // `agent-init` er idempotent i nvt (skriver/oppdaterer `.agents/<navn>/`);
-    // vi kjører den likevel bare når instansen ikke er oppe, for å ikke
-    // overskrive en config et menneske har justert i en levende sesjon.
     if (!(await this.isRunning(instance))) {
-      this.log(`agent-init NAME=${instance} TYPE=${this.opts.agentType}`);
-      await this.make(["agent-init", `NAME=${instance}`, `TYPE=${this.opts.agentType}`]);
+      // Configen må ligge der FØR init: `agent-init` skriver nvt-malen bare
+      // når fila ikke finnes, og malen har ikke identiteten vi trenger.
+      await this.ensureAgentConfig(instance);
+
+      const userMode = this.opts.userMode ?? "non-root";
+      this.log(`agent-init --name ${instance} --type ${this.opts.agentType} --user ${userMode}`);
+      // Direkte script-kall: make-målet forwarder ikke --user (se topp av fila).
+      await this.run("bash", [
+        "scripts/agent-init.sh",
+        "--name",
+        instance,
+        "--type",
+        this.opts.agentType,
+        "--autonomy",
+        this.opts.autonomy ?? "trusted-local",
+        "--user",
+        userMode,
+      ]);
       this.log(`agent-up NAME=${instance}`);
-      await this.make(["agent-up", `NAME=${instance}`]);
+      await this.run("make", ["agent-up", `NAME=${instance}`]);
+      // Ny sesjon ⇒ onboardingen kan stå der igjen.
+      this.readyConfirmed.delete(instance);
     }
     this.started.add(instance);
     return ref;
+  }
+
+  /**
+   * Skriver `agent.yaml` når den mangler, og verifiserer identiteten når den
+   * finnes. Vi retter aldri en eksisterende config: den kan være håndredigert i
+   * en levende sesjon, og en stille omskriving er verre enn en ærlig feil.
+   */
+  private async ensureAgentConfig(instance: string): Promise<void> {
+    const configPath = this.agentConfigPath(instance);
+    const existing = await this.fs.readFile(configPath);
+    if (existing !== null) {
+      const problem = identityProblem(existing, configPath);
+      if (problem?.level === "error") throw new Error(problem.message);
+      if (problem) this.log(`ADVARSEL: ${problem.message}`);
+      return;
+    }
+    const content = renderAgentConfig({
+      ...this.opts.agentConfig,
+      agentType: this.opts.agentType,
+      userMode: this.opts.userMode ?? "non-root",
+      runtimeArgs: runtimeArgsFor(this.opts.agentType, this.opts.autonomy ?? "trusted-local"),
+    });
+    await this.fs.mkdirp(path.dirname(configPath));
+    await this.fs.writeFile(configPath, content);
+    this.log(`skrev ${configPath} (identity.mode: explicit)`);
+  }
+
+  /**
+   * Venter til sesjonen kan ta imot en prompt (M0-funn 5).
+   *
+   * Klar-tilstand = `session-launched`-markøren finnes **og** tmux-sesjonen
+   * svarer **og** panelet ikke viser en onboarding-dialog. Står en dialog der,
+   * sendes ett Enter per runde (maks `maxEnterPresses`) — vi sender aldri Enter
+   * i blinde, for et Enter inn i en sesjon som venter på svar ville sendt av
+   * halvskrevet input.
+   *
+   * Kaster ved timeout. Feilmeldingen sier hva som manglet, men gjengir
+   * *aldri* panelinnholdet: det havner i resultatlinja og videre til Slack, og
+   * en tmux-skjerm kan inneholde hva som helst.
+   */
+  async waitUntilReady(
+    instance: NvtInstance,
+    opts: { timeoutMs: number; signal?: AbortSignal },
+  ): Promise<void> {
+    const name = instance.instance;
+    const strict = !this.readyConfirmed.has(name);
+    const pollMs = this.opts.readyPollMs ?? 2000;
+    const maxEnter = this.opts.maxEnterPresses ?? 3;
+    const deadline = Date.now() + opts.timeoutMs;
+
+    let marker = false;
+    let sessionAlive = false;
+    let state: PaneState = "unknown";
+    let enters = 0;
+
+    for (;;) {
+      if (opts.signal?.aborted) {
+        throw new Error(
+          `klar-sjekken for ${name} ble avbrutt (broen avslutter) — ingen prompt ble sendt`,
+        );
+      }
+
+      marker = await this.readyMarkerPresent(name);
+      const pane = await this.capturePane(name);
+      sessionAlive = pane.ok;
+      state = pane.ok ? classifyPane(pane.text, this.patterns) : "unknown";
+
+      if (marker && sessionAlive) {
+        if (state === "onboarding") {
+          if (enters < maxEnter) {
+            enters++;
+            this.log(
+              `${name}: onboarding-dialog i tmux-panelet — sender Enter (${enters}/${maxEnter})`,
+            );
+            await this.sendEnter(name);
+          }
+        } else if (state === "ready") {
+          if (strict) this.log(`${name}: klar-prompt i tmux-panelet etter ${enters} Enter`);
+          this.readyConfirmed.add(name);
+          return;
+        } else if (!strict) {
+          // Sesjonen lever, ingen dialog i veien, og vi har sett klar-prompten
+          // før i denne prosessen. Da er den enten klar eller midt i arbeid —
+          // agentd køer prompten uansett.
+          return;
+        }
+      }
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await this.sleep(Math.min(pollMs, remaining));
+    }
+
+    throw new Error(
+      `sesjonen i ${name} ble ikke klar innen ${Math.round(opts.timeoutMs / 1000)}s ` +
+        `(session-launched-markør: ${yesNo(marker)}, tmux-sesjon «${this.session}»: ` +
+        `${yesNo(sessionAlive)}, panel: ${state}, Enter sendt: ${enters}). ` +
+        `Ingen prompt ble sendt — den ville blitt spist av onboardingen. ` +
+        `Sjekk sesjonen i code-server: http://${name}.agent.localhost:4090. ` +
+        `Har claude byttet ordlyd i TUI-et, kan mønsteret settes med NVT_READY_PATTERN.`,
+    );
   }
 
   async sendPrompt(instance: NvtInstance, prompt: string): Promise<void> {
@@ -170,16 +351,57 @@ export class DockerNvtDriver implements NvtDriver {
 
   async stopInstance(instance: NvtInstance): Promise<void> {
     this.log(`agent-down NAME=${instance.instance}`);
-    await this.make(["agent-down", `NAME=${instance.instance}`]);
+    await this.run("make", ["agent-down", `NAME=${instance.instance}`]);
     this.started.delete(instance.instance);
+    // Neste oppstart er en ny sesjon — onboardingen kan komme tilbake.
+    this.readyConfirmed.delete(instance.instance);
   }
 
-  private async make(args: string[]): Promise<void> {
-    const { code, stderr } = await this.exec("make", args, {
-      cwd: this.opts.nvtRoot,
-    });
+  /**
+   * Markøren `agentd` selv venter på. Stien slås opp med samme
+   * env-presedens som `runtime/core/start-agent-session.sh` bruker, i
+   * containerens eget skall — vi gjetter ikke på HOME.
+   */
+  private async readyMarkerPresent(instance: string): Promise<boolean> {
+    const { code } = await this.exec(
+      "docker",
+      [
+        "exec",
+        this.containerName(instance),
+        "sh",
+        "-c",
+        'test -f "${NVT_AGENT_SESSION_READY_MARKER:-${NVT_STATE_DIR:-$HOME/.nvt-agent}/agentd/session-launched}"',
+      ],
+      {},
+    );
+    return code === 0;
+  }
+
+  /** Panelinnholdet i tmux-sesjonen. `ok: false` = ingen sesjon (ennå). */
+  private async capturePane(instance: string): Promise<{ ok: boolean; text: string }> {
+    const { code, stdout } = await this.exec(
+      "docker",
+      ["exec", this.containerName(instance), "tmux", "capture-pane", "-p", "-t", this.session],
+      {},
+    );
+    return { ok: code === 0, text: stdout };
+  }
+
+  private async sendEnter(instance: string): Promise<void> {
+    await this.exec(
+      "docker",
+      ["exec", this.containerName(instance), "tmux", "send-keys", "-t", this.session, "Enter"],
+      {},
+    );
+  }
+
+  /** Kjører en kommando i nvt-sjekkouten og kaster med målet i meldingen. */
+  private async run(cmd: string, args: string[]): Promise<void> {
+    const { code, stderr } = await this.exec(cmd, args, { cwd: this.opts.nvtRoot });
     if (code !== 0) {
-      throw new Error(`make ${args.join(" ")} feilet (exit ${code}): ${firstLine(stderr)}`);
+      throw new Error(
+        `${cmd} ${args.join(" ")} feilet (exit ${code}): ${firstLine(stderr)}`,
+      );
     }
   }
 
@@ -194,8 +416,19 @@ export class DockerNvtDriver implements NvtDriver {
 }
 
 /**
+ * Samme utledning som `scripts/agent-init.sh` gjør: `trusted-local` slår på
+ * bypass-flagget. Vi trenger den fordi vi skriver `agent.yaml` selv.
+ */
+export function runtimeArgsFor(agentType: string, autonomy: string): string[] {
+  if (autonomy !== "trusted-local") return [];
+  if (agentType === "claude") return ["--dangerously-skip-permissions"];
+  if (agentType === "codex") return ["--sandbox", "danger-full-access", "--ask-for-approval", "never"];
+  throw new Error(`ukjent agent-type «${agentType}» — kan ikke utlede runtime-args til agent.yaml`);
+}
+
+/**
  * Godtar både `type` og `event` som feltnavn — hvilket nvt faktisk bruker er
- * et M0-spørsmål. Ugyldige linjer ignoreres.
+ * ikke verifisert ende-til-ende. Ugyldige linjer ignoreres.
  */
 export function isDoneEvent(line: string): boolean {
   const trimmed = line.trim();
@@ -217,6 +450,25 @@ export function isDoneEvent(line: string): boolean {
 function firstLine(text: string): string {
   return text.split("\n").find((l) => l.trim() !== "")?.trim() ?? "";
 }
+
+function yesNo(value: boolean): string {
+  return value ? "ja" : "nei";
+}
+
+const nodeFs: FsFns = {
+  readFile: async (target) => {
+    try {
+      return await readFile(target, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  },
+  writeFile: (target, content) => writeFile(target, content, "utf8"),
+  mkdirp: async (target) => {
+    await mkdir(target, { recursive: true });
+  },
+};
 
 const runCommand: ExecFn = (cmd, args, opts) =>
   new Promise((resolve) => {

--- a/apps/nvt-bridge/src/nvt/docker.ts
+++ b/apps/nvt-bridge/src/nvt/docker.ts
@@ -106,11 +106,13 @@ export class DockerNvtDriver implements NvtDriver {
   /** Instanser vi har kjørt `agent-up` for i denne prosessen. */
   private readonly started = new Set<string>();
   /**
-   * Instanser vi har sett klar-prompten i. Første prompt i en sesjon krever
-   * *positiv* klar-tilstand; senere prompts godtar «lever, ingen dialog» — da
-   * kan sesjonen være midt i arbeid, og agentd køer prompten selv.
+   * Instanser vi har sett klar-prompten i, med *hvilken* container-inkarnasjon
+   * det gjaldt (`<id> <startedAt>`). Restartes containeren utenfor broen
+   * (`docker restart`, host-reboot med `restart: unless-stopped`), er det en ny
+   * sesjon med ny onboarding — og da må klar-sjekken gjøres på nytt selv om
+   * `agent-up` aldri ble kjørt herfra.
    */
-  private readonly readyConfirmed = new Set<string>();
+  private readonly readyConfirmed = new Map<string, string>();
 
   constructor(opts: DockerNvtDriverOptions) {
     this.opts = opts;
@@ -196,11 +198,21 @@ export class DockerNvtDriver implements NvtDriver {
   /**
    * Venter til sesjonen kan ta imot en prompt (M0-funn 5).
    *
-   * Klar-tilstand = `session-launched`-markøren finnes **og** tmux-sesjonen
-   * svarer **og** panelet ikke viser en onboarding-dialog. Står en dialog der,
-   * sendes ett Enter per runde (maks `maxEnterPresses`) — vi sender aldri Enter
-   * i blinde, for et Enter inn i en sesjon som venter på svar ville sendt av
-   * halvskrevet input.
+   * Onboardingen er en **sesjonsstart**-tilstand, så sjekken har to nivåer:
+   *
+   * - *Fersk sesjon* (vi har ikke sett klar-prompten i denne container-
+   *   inkarnasjonen): markøren må finnes, tmux svare, og panelet vise
+   *   klar-prompt. Står en onboarding-dialog der, sendes ett Enter per runde
+   *   (maks `maxEnterPresses`).
+   * - *Bekreftet sesjon*: markør + levende tmux er nok. Vi leser ikke panelet,
+   *   og sender ikke Enter. Grunnen er at panelet da inneholder transkriptet —
+   *   inkludert den delegerte oppgaveteksten, som er upålitelig input. Å la
+   *   den styre om broen trykker Enter (eller nekter å levere) ville gitt
+   *   avsender en knapp hen ikke skal ha. Agenten kan dessuten være midt i
+   *   arbeid, og `agentd` køer prompten selv.
+   *
+   * Enter sendes altså aldri i blinde: bare når en dialog faktisk er tegnet i
+   * en sesjon som ikke har vært i bruk.
    *
    * Kaster ved timeout. Feilmeldingen sier hva som manglet, men gjengir
    * *aldri* panelinnholdet: det havner i resultatlinja og videre til Slack, og
@@ -211,46 +223,44 @@ export class DockerNvtDriver implements NvtDriver {
     opts: { timeoutMs: number; signal?: AbortSignal },
   ): Promise<void> {
     const name = instance.instance;
-    const strict = !this.readyConfirmed.has(name);
     const pollMs = this.opts.readyPollMs ?? 2000;
     const maxEnter = this.opts.maxEnterPresses ?? 3;
     const deadline = Date.now() + opts.timeoutMs;
 
     let marker = false;
     let sessionAlive = false;
-    let state: PaneState = "unknown";
+    let state: PaneState | "ikke lest" = "ikke lest";
     let enters = 0;
 
     for (;;) {
       if (opts.signal?.aborted) {
         throw new Error(
-          `klar-sjekken for ${name} ble avbrutt (broen avslutter) — ingen prompt ble sendt`,
+          `klar-sjekken for ${name} ble avbrutt fordi broen avslutter (deploy/omstart). ` +
+            `Ingen prompt ble sendt, og ingenting er levert — oppgaven må sendes på nytt.`,
         );
       }
 
+      const incarnation = await this.incarnation(name);
+      const strict = incarnation === null || this.readyConfirmed.get(name) !== incarnation;
+
       marker = await this.readyMarkerPresent(name);
-      const pane = await this.capturePane(name);
+      const pane = strict ? await this.capturePane(name) : await this.sessionExists(name);
       sessionAlive = pane.ok;
-      state = pane.ok ? classifyPane(pane.text, this.patterns) : "unknown";
+      state = strict ? (pane.ok ? classifyPane(pane.text, this.patterns) : "unknown") : "ikke lest";
 
       if (marker && sessionAlive) {
-        if (state === "onboarding") {
-          if (enters < maxEnter) {
-            enters++;
-            this.log(
-              `${name}: onboarding-dialog i tmux-panelet — sender Enter (${enters}/${maxEnter})`,
-            );
-            await this.sendEnter(name);
-          }
-        } else if (state === "ready") {
-          if (strict) this.log(`${name}: klar-prompt i tmux-panelet etter ${enters} Enter`);
-          this.readyConfirmed.add(name);
+        if (!strict) return;
+        if (state === "ready") {
+          this.log(`${name}: klar-prompt i tmux-panelet etter ${enters} Enter`);
+          if (incarnation !== null) this.readyConfirmed.set(name, incarnation);
           return;
-        } else if (!strict) {
-          // Sesjonen lever, ingen dialog i veien, og vi har sett klar-prompten
-          // før i denne prosessen. Da er den enten klar eller midt i arbeid —
-          // agentd køer prompten uansett.
-          return;
+        }
+        if (state === "onboarding" && enters < maxEnter) {
+          enters++;
+          this.log(
+            `${name}: onboarding-dialog i tmux-panelet — sender Enter (${enters}/${maxEnter})`,
+          );
+          await this.sendEnter(name);
         }
       }
 
@@ -262,7 +272,8 @@ export class DockerNvtDriver implements NvtDriver {
     throw new Error(
       `sesjonen i ${name} ble ikke klar innen ${Math.round(opts.timeoutMs / 1000)}s ` +
         `(session-launched-markør: ${yesNo(marker)}, tmux-sesjon «${this.session}»: ` +
-        `${yesNo(sessionAlive)}, panel: ${state}, Enter sendt: ${enters}). ` +
+        `${yesNo(sessionAlive)}, panel: ${sessionAlive ? state : "ikke lest (ingen sesjon)"}, ` +
+        `Enter sendt: ${enters}). ` +
         `Ingen prompt ble sendt — den ville blitt spist av onboardingen. ` +
         `Sjekk sesjonen i code-server: http://${name}.agent.localhost:4090. ` +
         `Har claude byttet ordlyd i TUI-et, kan mønsteret settes med NVT_READY_PATTERN.`,
@@ -387,12 +398,47 @@ export class DockerNvtDriver implements NvtDriver {
     return { ok: code === 0, text: stdout };
   }
 
+  /** Lever tmux-sesjonen? Brukes når vi ikke skal lese panelinnholdet. */
+  private async sessionExists(instance: string): Promise<{ ok: boolean; text: string }> {
+    const { code } = await this.exec(
+      "docker",
+      ["exec", this.containerName(instance), "tmux", "has-session", "-t", this.session],
+      {},
+    );
+    return { ok: code === 0, text: "" };
+  }
+
+  /**
+   * `<container-id> <startet-tidspunkt>` — identifiserer *denne* oppstarten av
+   * containeren. `null` når containeren ikke finnes eller docker svarer rart;
+   * da behandles sesjonen som fersk (streng sjekk), som er den trygge siden.
+   */
+  private async incarnation(instance: string): Promise<string | null> {
+    const { code, stdout } = await this.exec(
+      "docker",
+      [
+        "inspect",
+        "-f",
+        "{{.Id}} {{.State.StartedAt}}",
+        this.containerName(instance),
+      ],
+      {},
+    );
+    const value = stdout.trim();
+    return code === 0 && value !== "" ? value : null;
+  }
+
   private async sendEnter(instance: string): Promise<void> {
-    await this.exec(
+    const { code, stderr } = await this.exec(
       "docker",
       ["exec", this.containerName(instance), "tmux", "send-keys", "-t", this.session, "Enter"],
       {},
     );
+    if (code !== 0) {
+      // Loggen er audit-sporet: den skal ikke påstå at et Enter ble sendt hvis
+      // tmux avviste det.
+      this.log(`${instance}: send-keys feilet (exit ${code}): ${firstLine(stderr)}`);
+    }
   }
 
   /** Kjører en kommando i nvt-sjekkouten og kaster med målet i meldingen. */

--- a/apps/nvt-bridge/src/nvt/driver.ts
+++ b/apps/nvt-bridge/src/nvt/driver.ts
@@ -33,9 +33,30 @@ export interface NvtDriver {
   ensureInstance(topic: string, instance: string): Promise<NvtInstance>;
 
   /**
+   * Venter til CLI-sesjonen faktisk kan ta imot en prompt, og kaster ved
+   * timeout. **Må kalles før hver `sendPrompt`** — det er en del av kontrakten,
+   * ikke en optimalisering.
+   *
+   * Grunnen er M0-funn 5: claude-onboardingen (velkomstskjerm + trust-dialog)
+   * spiser prompts som injiseres for tidlig. `agentd` venter på at
+   * `session-launched`-markøren og tmux-sesjonen finnes, men *ikke* på at
+   * claude er kommet gjennom dialogene — da havner prompten i en dialog i
+   * stedet for i sesjonen, og oppgaven forsvinner uten spor.
+   *
+   * Kaster ved timeout (aldri «antatt klar»): broen skriver da en
+   * `status:"error"`-linje, og prompten sendes ikke.
+   */
+  waitUntilReady(
+    instance: NvtInstance,
+    opts: { timeoutMs: number; signal?: AbortSignal },
+  ): Promise<void>;
+
+  /**
    * Injiserer en prompt i instansens levende CLI-sesjon:
    * `agentdctl prompt --source host --external`. `--external` gir
    * «untrusted input»-preamblen — delegerte prompts er upålitelig input.
+   *
+   * Forutsetter at `waitUntilReady` har svart OK for instansen.
    */
   sendPrompt(instance: NvtInstance, prompt: string): Promise<void>;
 

--- a/apps/nvt-bridge/src/nvt/dryrun.ts
+++ b/apps/nvt-bridge/src/nvt/dryrun.ts
@@ -17,8 +17,18 @@ export class DryRunNvtDriver implements NvtDriver {
   }
 
   async ensureInstance(topic: string, instance: string): Promise<NvtInstance> {
-    this.log(`[dry-run] make agent-init NAME=${instance} && make agent-up NAME=${instance}`);
+    this.log(
+      `[dry-run] bash scripts/agent-init.sh --name ${instance} --user non-root ` +
+        `&& make agent-up NAME=${instance}`,
+    );
     return { topic, instance };
+  }
+
+  async waitUntilReady(instance: NvtInstance): Promise<void> {
+    this.log(
+      `[dry-run] klar-sjekk for ${instance.instance}: session-launched-markør + tmux-panel ` +
+        `(Enter gjennom onboardingen ved behov)`,
+    );
   }
 
   async sendPrompt(instance: NvtInstance, prompt: string): Promise<void> {

--- a/apps/nvt-bridge/src/nvt/fake.ts
+++ b/apps/nvt-bridge/src/nvt/fake.ts
@@ -3,6 +3,7 @@ import type { DoneOutcome, NvtDriver, NvtInstance } from "./driver.ts";
 /** Én ting som skjedde mot fake-driveren, i rekkefølge. */
 export type FakeCall =
   | { kind: "ensure"; topic: string; instance: string }
+  | { kind: "ready"; instance: string; topic: string }
   | { kind: "prompt"; instance: string; topic: string; prompt: string }
   | { kind: "wait"; instance: string; topic: string }
   | { kind: "stop"; instance: string; topic: string };
@@ -35,7 +36,16 @@ export class FakeNvtDriver implements NvtDriver {
     at: "1970-01-01T00:00:00.000Z",
   });
 
+  /**
+   * Kalles av `waitUntilReady`. Kast for å simulere en sesjon som aldri blir
+   * klar (onboarding-dialogen står, tmux svarer ikke) — broen skal da skrive en
+   * `status:"error"`-linje UTEN å ha sendt prompten.
+   */
+  onReady: (ctx: { instance: NvtInstance }) => Promise<void> | void = () => {};
+
   private nextOutcome = new Map<string, DoneOutcome>();
+  /** Instanser `waitUntilReady` har svart OK for. */
+  private readonly ready = new Set<string>();
 
   async ensureInstance(topic: string, instance: string): Promise<NvtInstance> {
     this.calls.push({ kind: "ensure", topic, instance });
@@ -44,7 +54,24 @@ export class FakeNvtDriver implements NvtDriver {
     return { topic, instance };
   }
 
+  async waitUntilReady(instance: NvtInstance): Promise<void> {
+    this.calls.push({
+      kind: "ready",
+      instance: instance.instance,
+      topic: instance.topic,
+    });
+    await this.onReady({ instance });
+    this.ready.add(instance.instance);
+  }
+
   async sendPrompt(instance: NvtInstance, prompt: string): Promise<void> {
+    // Kontrakten, håndhevet: en prompt før klar-sjekken ville blitt spist av
+    // claude-onboardingen (M0-funn 5). Det skal ikke kunne skje uoppdaget.
+    if (!this.ready.has(instance.instance)) {
+      throw new Error(
+        `kontraktbrudd: sendPrompt til ${instance.instance} uten at waitUntilReady har svart OK`,
+      );
+    }
     this.calls.push({
       kind: "prompt",
       instance: instance.instance,
@@ -90,6 +117,8 @@ export class FakeNvtDriver implements NvtDriver {
       topic: instance.topic,
     });
     this.live.delete(instance.instance);
+    // Ny sesjon neste gang ⇒ klar-sjekken må gjøres om igjen.
+    this.ready.delete(instance.instance);
   }
 
   /** Prompt-tekstene som er injisert, i rekkefølge. */

--- a/apps/nvt-bridge/src/nvt/paths.test.ts
+++ b/apps/nvt-bridge/src/nvt/paths.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   agentCanTraverse,
+  agentCanWrite,
   ancestorPaths,
   assertAgentCanTraverse,
   traversalProblems,
@@ -60,10 +61,35 @@ test("en manglende katalog rapporteres, og resten av stien droppes", async () =>
   assert.deepEqual(problems, [{ path: "/srv", reason: "missing" }]);
 });
 
+test("agentCanWrite: w for other, eller eier/gruppe 1000 med w", () => {
+  assert.equal(agentCanWrite({ mode: 0o777, uid: 0, gid: 0 }), true);
+  assert.equal(agentCanWrite({ mode: 0o755, uid: 0, gid: 0 }), false, "root-eid triggers/");
+  assert.equal(agentCanWrite({ mode: 0o755, uid: 1000, gid: 1000 }), true);
+  assert.equal(agentCanWrite({ mode: 0o775, uid: 0, gid: 1000 }), true);
+});
+
+test("skrivekrav gjelder katalogen selv, ikke foreldrene", async () => {
+  const stat = fakeStat({
+    "/": { mode: 0o755 },
+    "/srv": { mode: 0o755 },
+    "/srv/triggers": { mode: 0o755, uid: 0, gid: 0 },
+  });
+  assert.deepEqual(await traversalProblems("/srv/triggers", stat), [], "traversering er ok");
+  const problems = await traversalProblems("/srv/triggers", stat, { requireWrite: true });
+  assert.deepEqual(problems, [
+    { path: "/srv/triggers", reason: "not-writable", mode: 0o755, uid: 0 },
+  ]);
+});
+
 test("assertAgentCanTraverse kaster med årsak, sti og /root-hintet", async () => {
   const stat = fakeStat({ "/": { mode: 0o755 }, "/root": { mode: 0o700 }, "/root/nvt": { mode: 0o755 } });
   await assert.rejects(
-    () => assertAgentCanTraverse("NVT_ROOT", "/root/nvt", { statFn: stat, platform: "linux" }),
+    () =>
+      assertAgentCanTraverse("NVT_ROOT", "/root/nvt", {
+        statFn: stat,
+        platform: "linux",
+        containerized: false,
+      }),
     (err: Error) => {
       assert.match(err.message, /NVT_ROOT="\/root\/nvt"/);
       assert.match(err.message, /\/root \(mode 0700, eier uid 0\)/);
@@ -79,6 +105,43 @@ test("relative stier avvises — bind-mounts kan ikke oversettes", async () => {
     () => assertAgentCanTraverse("NVT_ROOT", "../nvt-agent", { platform: "linux" }),
     /absolutt sti/,
   );
+});
+
+test("symlenker løses før vandringen (ellers skjules målets foreldre)", async () => {
+  // /opt/link → /root/hidden. Leksikalsk vandring ville aldri sett /root.
+  const stat = fakeStat({
+    "/": { mode: 0o755 },
+    "/opt": { mode: 0o755 },
+    "/opt/link": { mode: 0o777 },
+    "/root": { mode: 0o700 },
+    "/root/hidden": { mode: 0o755 },
+  });
+  await assert.rejects(
+    () =>
+      assertAgentCanTraverse("NVT_ROOT", "/opt/link", {
+        statFn: stat,
+        realpathFn: async (p) => (p === "/opt/link" ? "/root/hidden" : p),
+        platform: "linux",
+        containerized: false,
+      }),
+    (err: Error) => {
+      assert.match(err.message, /realpath: "\/root\/hidden"/);
+      assert.match(err.message, /\/root \(mode 0700/);
+      return true;
+    },
+  );
+});
+
+test("i container er funnet en advarsel — vi ser ikke hostens mode-bits", async () => {
+  const stat = fakeStat({ "/": { mode: 0o755 }, "/root": { mode: 0o700 }, "/root/nvt": { mode: 0o755 } });
+  const logged: string[] = [];
+  await assertAgentCanTraverse("NVT_ROOT", "/root/nvt", {
+    statFn: stat,
+    platform: "linux",
+    containerized: true,
+    log: (m) => logged.push(m),
+  });
+  assert.match(logged[0]!, /ADVARSEL.*kjører i container og ser ikke hostens mode-bits/s);
 });
 
 test("utenfor Linux er funnet en advarsel, ikke en blokkering", async () => {

--- a/apps/nvt-bridge/src/nvt/paths.test.ts
+++ b/apps/nvt-bridge/src/nvt/paths.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  agentCanTraverse,
+  ancestorPaths,
+  assertAgentCanTraverse,
+  traversalProblems,
+  type StatFn,
+} from "./paths.ts";
+
+/** Kataloger med mode/eier, som en liten host. Ukjente stier «finnes ikke». */
+function fakeStat(tree: Record<string, { mode: number; uid?: number; gid?: number }>): StatFn {
+  return async (target) => {
+    const entry = tree[target];
+    if (!entry) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    return { mode: entry.mode, uid: entry.uid ?? 0, gid: entry.gid ?? 0 };
+  };
+}
+
+test("ancestorPaths gir alle ledd, rot først", () => {
+  assert.deepEqual(ancestorPaths("/srv/nvt-agent"), ["/", "/srv", "/srv/nvt-agent"]);
+  assert.deepEqual(ancestorPaths("/"), ["/"]);
+  assert.deepEqual(ancestorPaths("/a/b/../c"), ["/", "/a", "/a/c"]);
+});
+
+test("agentCanTraverse: o+x, eller eier/gruppe 1000 med x", () => {
+  assert.equal(agentCanTraverse({ mode: 0o755, uid: 0, gid: 0 }), true);
+  assert.equal(agentCanTraverse({ mode: 0o700, uid: 0, gid: 0 }), false, "/root");
+  assert.equal(agentCanTraverse({ mode: 0o700, uid: 1000, gid: 1000 }), true, "egen katalog");
+  assert.equal(agentCanTraverse({ mode: 0o710, uid: 0, gid: 1000 }), true, "gruppe 1000");
+  assert.equal(agentCanTraverse({ mode: 0o644, uid: 1000, gid: 1000 }), false, "ingen x");
+});
+
+test("traversalProblems peker på det leddet som stopper uid 1000", async () => {
+  const stat = fakeStat({
+    "/": { mode: 0o755 },
+    "/root": { mode: 0o700 },
+    "/root/src": { mode: 0o755, uid: 0 },
+  });
+  const problems = await traversalProblems("/root/src", stat);
+  assert.deepEqual(
+    problems.map((p) => p.path),
+    ["/root"],
+  );
+  assert.equal(problems[0]!.mode, 0o700);
+});
+
+test("traversalProblems er tom for en sti alle kommer gjennom", async () => {
+  const stat = fakeStat({
+    "/": { mode: 0o755 },
+    "/srv": { mode: 0o755 },
+    "/srv/nvt-agent": { mode: 0o750, uid: 1000, gid: 1000 },
+  });
+  assert.deepEqual(await traversalProblems("/srv/nvt-agent", stat), []);
+});
+
+test("en manglende katalog rapporteres, og resten av stien droppes", async () => {
+  const stat = fakeStat({ "/": { mode: 0o755 } });
+  const problems = await traversalProblems("/srv/nvt-agent", stat);
+  assert.deepEqual(problems, [{ path: "/srv", reason: "missing" }]);
+});
+
+test("assertAgentCanTraverse kaster med årsak, sti og /root-hintet", async () => {
+  const stat = fakeStat({ "/": { mode: 0o755 }, "/root": { mode: 0o700 }, "/root/nvt": { mode: 0o755 } });
+  await assert.rejects(
+    () => assertAgentCanTraverse("NVT_ROOT", "/root/nvt", { statFn: stat, platform: "linux" }),
+    (err: Error) => {
+      assert.match(err.message, /NVT_ROOT="\/root\/nvt"/);
+      assert.match(err.message, /\/root \(mode 0700, eier uid 0\)/);
+      assert.match(err.message, /uid 1000/);
+      assert.match(err.message, /\/srv\/nvt-agent/, "hintet om en fungerende sti");
+      return true;
+    },
+  );
+});
+
+test("relative stier avvises — bind-mounts kan ikke oversettes", async () => {
+  await assert.rejects(
+    () => assertAgentCanTraverse("NVT_ROOT", "../nvt-agent", { platform: "linux" }),
+    /absolutt sti/,
+  );
+});
+
+test("utenfor Linux er funnet en advarsel, ikke en blokkering", async () => {
+  const stat = fakeStat({ "/": { mode: 0o755 }, "/Users": { mode: 0o700 }, "/Users/nvt": { mode: 0o755 } });
+  const logged: string[] = [];
+  await assertAgentCanTraverse("NVT_ROOT", "/Users/nvt", {
+    statFn: stat,
+    platform: "darwin",
+    log: (m) => logged.push(m),
+  });
+  assert.equal(logged.length, 1);
+  assert.match(logged[0]!, /ADVARSEL.*ikke håndhevet på darwin/s);
+});
+
+test("rømningsluka hopper over sjekken og sier det", async () => {
+  const logged: string[] = [];
+  await assertAgentCanTraverse("NVT_ROOT", "/root/nvt", {
+    skip: true,
+    platform: "linux",
+    log: (m) => logged.push(m),
+    statFn: async () => {
+      throw new Error("skal ikke kalles");
+    },
+  });
+  assert.match(logged[0]!, /hoppet over/);
+});

--- a/apps/nvt-bridge/src/nvt/paths.ts
+++ b/apps/nvt-bridge/src/nvt/paths.ts
@@ -1,4 +1,5 @@
-import { stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 
 /**
@@ -12,9 +13,13 @@ import path from "node:path";
  * kryptisk feil langt fra årsaken. M0 brant en økt på nettopp dette, så broen
  * sier det fra før den starter å polle.
  *
- * Sjekken er en *host*-sjekk og kjøres bare på Linux. Docker Desktop på macOS
- * mapper eierskap i virtiofs-laget, så de samme mode-bitene der ville gitt
- * falske avvisninger — se `assertAgentCanTraverse`.
+ * Sjekken håndheves bare når broen faktisk *ser* hosten: på Linux, og ikke i
+ * container. Kjører broen selv i container (den dokumenterte driftsformen), er
+ * bare `NVT_ROOT` og triggers-katalogen bind-mountet — mellomleddene er
+ * mount-point-foreldre Docker har laget, med helt andre mode-bits enn hostens.
+ * Da ville både falske avvisninger og falsk trygghet vært mulig, så funnene
+ * logges som advarsel i stedet. Det samme gjelder macOS, der Docker Desktop
+ * mapper eierskap i virtiofs-laget. Se `assertAgentCanTraverse`.
  */
 
 /** Uid/gid agenten kjører som i nvt-ens non-root-modus (`--user non-root`). */
@@ -32,7 +37,7 @@ export type StatFn = (target: string) => Promise<StatResult>;
 export interface TraversalProblem {
   path: string;
   /** Mangler stien helt, er `mode`/`uid` ukjent. */
-  reason: "missing" | "not-traversable";
+  reason: "missing" | "not-traversable" | "not-writable";
   mode?: number;
   uid?: number;
 }
@@ -62,13 +67,29 @@ export function agentCanTraverse(info: StatResult): boolean {
   return false;
 }
 
-/** Alle ledd i stien uid 1000 ikke kommer gjennom, øverste først. */
+/** Kan uid 1000 skrive i katalogen? Brukes for triggers/, som agenten appender i. */
+export function agentCanWrite(info: StatResult): boolean {
+  if ((info.mode & 0o002) !== 0) return true;
+  if (info.uid === AGENT_UID && (info.mode & 0o200) !== 0) return true;
+  if (info.gid === AGENT_GID && (info.mode & 0o020) !== 0) return true;
+  return false;
+}
+
+/**
+ * Alle ledd i stien uid 1000 ikke kommer gjennom, øverste først.
+ *
+ * `absolute` forventes å være realpath-løst (se `assertAgentCanTraverse`):
+ * vandringen er leksikalsk, så en symlenke midt i stien ville ellers skjult at
+ * *målets* foreldre er ugjennomtrengelige.
+ */
 export async function traversalProblems(
   absolute: string,
   statFn: StatFn = defaultStat,
+  opts: { requireWrite?: boolean } = {},
 ): Promise<TraversalProblem[]> {
   const problems: TraversalProblem[] = [];
-  for (const dir of ancestorPaths(absolute)) {
+  const dirs = ancestorPaths(absolute);
+  for (const dir of dirs) {
     let info: StatResult;
     try {
       info = await statFn(dir);
@@ -85,14 +106,32 @@ export async function traversalProblems(
         uid: info.uid,
       });
     }
+    // Skrivetilgang kreves bare på katalogen selv, ikke på foreldrene.
+    if (opts.requireWrite && dir === dirs.at(-1) && !agentCanWrite(info)) {
+      problems.push({
+        path: dir,
+        reason: "not-writable",
+        mode: info.mode & 0o7777,
+        uid: info.uid,
+      });
+    }
   }
   return problems;
 }
 
 export interface PathCheckOptions {
   statFn?: StatFn;
+  /** Løser symlenker før vandringen. Default `fs.realpath`. */
+  realpathFn?: (target: string) => Promise<string>;
   /** Default `process.platform`. Håndheves bare på Linux (se over). */
   platform?: string;
+  /**
+   * Kjører broen selv i container? Default: finnes `/.dockerenv`. Da ser vi
+   * ikke hostens mode-bits, og funnene blir en advarsel.
+   */
+  containerized?: boolean;
+  /** Krev at agenten kan skrive i katalogen (triggers/). */
+  requireWrite?: boolean;
   /** Rømningsluke: `NVT_BRIDGE_SKIP_PATH_CHECK=1`. */
   skip?: boolean;
   log?: (message: string) => void;
@@ -102,8 +141,9 @@ export interface PathCheckOptions {
  * Fail-fast før broen begynner å polle: kaster med en melding som peker på
  * *hvilket* ledd i stien som stopper uid 1000, og hva man gjør med det.
  *
- * På andre plattformer enn Linux logges funnene som en advarsel i stedet for å
- * kaste: mode-bitene på hosten er da ikke det agenten faktisk møter.
+ * Kaster bare når broen faktisk ser hosten (Linux, ikke i container) — ellers
+ * logges funnet som advarsel, fordi mode-bitene vi leser da ikke er de agenten
+ * møter. Se kommentaren øverst i fila.
  */
 export async function assertAgentCanTraverse(
   label: string,
@@ -122,25 +162,50 @@ export async function assertAgentCanTraverse(
     );
   }
 
-  const problems = await traversalProblems(absolute, opts.statFn);
+  // Symlenker: vandringen under er leksikalsk, så vi må se på den faktiske
+  // stien. Feiler realpath (finnes ikke), sier vandringen det tydeligere.
+  const realpathFn = opts.realpathFn ?? defaultRealpath;
+  let resolved = absolute;
+  try {
+    resolved = await realpathFn(absolute);
+  } catch {
+    // Beholder den oppgitte stien; `traversalProblems` rapporterer «missing».
+  }
+
+  const problems = await traversalProblems(resolved, opts.statFn, {
+    requireWrite: opts.requireWrite,
+  });
   if (problems.length === 0) return;
 
   const details = problems
-    .map((p) =>
-      p.reason === "missing"
-        ? `${p.path} (finnes ikke, eller broen får ikke lese den)`
-        : `${p.path} (mode ${(p.mode ?? 0).toString(8).padStart(4, "0")}, eier uid ${p.uid})`,
-    )
+    .map((p) => {
+      const mode = `mode ${(p.mode ?? 0).toString(8).padStart(4, "0")}, eier uid ${p.uid}`;
+      if (p.reason === "missing") return `${p.path} (finnes ikke, eller broen får ikke lese den)`;
+      if (p.reason === "not-writable") return `${p.path} (ikke skrivbar: ${mode})`;
+      return `${p.path} (${mode})`;
+    })
     .join(", ");
+  const via = resolved === absolute ? "" : ` (realpath: "${resolved}")`;
   const message =
-    `${label}="${absolute}" ligger bak katalog(er) som uid ${AGENT_UID} ikke kommer gjennom: ` +
-    `${details}. Agenten kjører som ${AGENT_UID}:${AGENT_GID} (nvt --user non-root) og får ` +
+    `${label}="${absolute}"${via} er ikke tilgjengelig for uid ${AGENT_UID}: ${details}. ` +
+    `Agenten kjører som ${AGENT_UID}:${AGENT_GID} (nvt --user non-root) og får ` +
     `«Permission denied» i bootstrap. Flytt sjekkouten til en sti alle kan traversere ` +
     `(f.eks. /srv/nvt-agent), eller gi leddet +x. Kjent M0-felle: /root er mode 0700.`;
 
   const platform = opts.platform ?? process.platform;
+  const containerized = opts.containerized ?? existsSync("/.dockerenv");
   if (platform !== "linux") {
     log(`ADVARSEL: ${message} (ikke håndhevet på ${platform})`);
+    return;
+  }
+  if (containerized) {
+    // I container er mellomleddene mount-point-foreldre Docker har laget, ikke
+    // hostens kataloger. Vi kan altså ikke stole på funnet — men det kan være
+    // ekte, så det skal stå i loggen.
+    log(
+      `ADVARSEL: ${message} (broen kjører i container og ser ikke hostens mode-bits — ` +
+        `sjekk stien på hosten selv)`,
+    );
     return;
   }
   throw new Error(message);
@@ -150,3 +215,5 @@ const defaultStat: StatFn = async (target) => {
   const info = await stat(target);
   return { mode: info.mode, uid: info.uid, gid: info.gid };
 };
+
+const defaultRealpath = (target: string): Promise<string> => realpath(target);

--- a/apps/nvt-bridge/src/nvt/paths.ts
+++ b/apps/nvt-bridge/src/nvt/paths.ts
@@ -1,0 +1,152 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Sti-validering mot M0-funn 2: nvt-sjekkouten (og alt annet som
+ * bind-mountes inn i instansen) må ligge et sted **uid 1000 kommer gjennom**.
+ *
+ * Hvorfor det er et reelt problem og ikke teori: workspacet bind-mountes på
+ * samme absolutte sti inne i containeren, og i non-root-modus kjører agenten
+ * som `1000:1000`. Ligger sjekkouten under `/root` (mode 700, eier 0), får
+ * bootstrap `Permission denied` — men først *inne* i containeren, som en
+ * kryptisk feil langt fra årsaken. M0 brant en økt på nettopp dette, så broen
+ * sier det fra før den starter å polle.
+ *
+ * Sjekken er en *host*-sjekk og kjøres bare på Linux. Docker Desktop på macOS
+ * mapper eierskap i virtiofs-laget, så de samme mode-bitene der ville gitt
+ * falske avvisninger — se `assertAgentCanTraverse`.
+ */
+
+/** Uid/gid agenten kjører som i nvt-ens non-root-modus (`--user non-root`). */
+export const AGENT_UID = 1000;
+export const AGENT_GID = 1000;
+
+export interface StatResult {
+  mode: number;
+  uid: number;
+  gid: number;
+}
+
+export type StatFn = (target: string) => Promise<StatResult>;
+
+export interface TraversalProblem {
+  path: string;
+  /** Mangler stien helt, er `mode`/`uid` ukjent. */
+  reason: "missing" | "not-traversable";
+  mode?: number;
+  uid?: number;
+}
+
+/** `/srv/nvt-agent` → `["/", "/srv", "/srv/nvt-agent"]`. */
+export function ancestorPaths(absolute: string): string[] {
+  const normalized = path.posix.normalize(absolute);
+  const segments = normalized.split("/").filter((s) => s !== "");
+  const out = ["/"];
+  let current = "";
+  for (const segment of segments) {
+    current += `/${segment}`;
+    out.push(current);
+  }
+  return out;
+}
+
+/**
+ * Kan uid 1000 traversere (`x`) denne katalogen? Vi ser bare på traverserings-
+ * biten: lese- og skrivetilgang på selve innholdet er en annen sak, og den
+ * feiler i det minste med en forståelig melding.
+ */
+export function agentCanTraverse(info: StatResult): boolean {
+  if ((info.mode & 0o001) !== 0) return true;
+  if (info.uid === AGENT_UID && (info.mode & 0o100) !== 0) return true;
+  if (info.gid === AGENT_GID && (info.mode & 0o010) !== 0) return true;
+  return false;
+}
+
+/** Alle ledd i stien uid 1000 ikke kommer gjennom, øverste først. */
+export async function traversalProblems(
+  absolute: string,
+  statFn: StatFn = defaultStat,
+): Promise<TraversalProblem[]> {
+  const problems: TraversalProblem[] = [];
+  for (const dir of ancestorPaths(absolute)) {
+    let info: StatResult;
+    try {
+      info = await statFn(dir);
+    } catch {
+      problems.push({ path: dir, reason: "missing" });
+      // Finnes ikke leddet, sier resten av stien ingenting.
+      break;
+    }
+    if (!agentCanTraverse(info)) {
+      problems.push({
+        path: dir,
+        reason: "not-traversable",
+        mode: info.mode & 0o7777,
+        uid: info.uid,
+      });
+    }
+  }
+  return problems;
+}
+
+export interface PathCheckOptions {
+  statFn?: StatFn;
+  /** Default `process.platform`. Håndheves bare på Linux (se over). */
+  platform?: string;
+  /** Rømningsluke: `NVT_BRIDGE_SKIP_PATH_CHECK=1`. */
+  skip?: boolean;
+  log?: (message: string) => void;
+}
+
+/**
+ * Fail-fast før broen begynner å polle: kaster med en melding som peker på
+ * *hvilket* ledd i stien som stopper uid 1000, og hva man gjør med det.
+ *
+ * På andre plattformer enn Linux logges funnene som en advarsel i stedet for å
+ * kaste: mode-bitene på hosten er da ikke det agenten faktisk møter.
+ */
+export async function assertAgentCanTraverse(
+  label: string,
+  absolute: string,
+  opts: PathCheckOptions = {},
+): Promise<void> {
+  const log = opts.log ?? (() => {});
+  if (opts.skip) {
+    log(`${label}: sti-sjekken er hoppet over (NVT_BRIDGE_SKIP_PATH_CHECK)`);
+    return;
+  }
+  if (!path.posix.isAbsolute(absolute)) {
+    throw new Error(
+      `${label} må være en absolutt sti (fikk "${absolute}"). ` +
+        `Bind-mounts løses av hostens Docker-daemon, så relative stier kan ikke oversettes.`,
+    );
+  }
+
+  const problems = await traversalProblems(absolute, opts.statFn);
+  if (problems.length === 0) return;
+
+  const details = problems
+    .map((p) =>
+      p.reason === "missing"
+        ? `${p.path} (finnes ikke, eller broen får ikke lese den)`
+        : `${p.path} (mode ${(p.mode ?? 0).toString(8).padStart(4, "0")}, eier uid ${p.uid})`,
+    )
+    .join(", ");
+  const message =
+    `${label}="${absolute}" ligger bak katalog(er) som uid ${AGENT_UID} ikke kommer gjennom: ` +
+    `${details}. Agenten kjører som ${AGENT_UID}:${AGENT_GID} (nvt --user non-root) og får ` +
+    `«Permission denied» i bootstrap. Flytt sjekkouten til en sti alle kan traversere ` +
+    `(f.eks. /srv/nvt-agent), eller gi leddet +x. Kjent M0-felle: /root er mode 0700.`;
+
+  const platform = opts.platform ?? process.platform;
+  if (platform !== "linux") {
+    log(`ADVARSEL: ${message} (ikke håndhevet på ${platform})`);
+    return;
+  }
+  throw new Error(message);
+}
+
+const defaultStat: StatFn = async (target) => {
+  const info = await stat(target);
+  return { mode: info.mode, uid: info.uid, gid: info.gid };
+};

--- a/apps/nvt-bridge/src/nvt/ready.test.ts
+++ b/apps/nvt-bridge/src/nvt/ready.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { classifyPane, DEFAULT_READY_PATTERN, patternFromEnv } from "./ready.ts";
+
+test("velkomstskjerm og trust-dialog klassifiseres som onboarding", () => {
+  assert.equal(classifyPane("╭─ Welcome to Claude Code ─╮"), "onboarding");
+  assert.equal(classifyPane("Do you trust the files in this folder?"), "onboarding");
+  assert.equal(classifyPane("  Press Enter to continue…"), "onboarding");
+});
+
+test("klar-prompten klassifiseres som ready", () => {
+  assert.equal(classifyPane("│ > │\n  ? for shortcuts"), "ready");
+  assert.equal(classifyPane("⏵⏵ Bypassing Permissions"), "ready");
+});
+
+test("en onboarding-dialog oppå en ellers klar sesjon er IKKE klar", () => {
+  const pane = ["│ >", "? for shortcuts", "Do you trust the files in this folder?"].join("\n");
+  assert.equal(
+    classifyPane(pane),
+    "onboarding",
+    "dialogen fanger tastetrykket — å gjette «ready» her er nettopp M0-feilen",
+  );
+});
+
+test("et panel som jobber er verken onboarding eller ready", () => {
+  assert.equal(classifyPane("● Kjører tester …\n  npm test"), "unknown");
+  assert.equal(classifyPane(""), "unknown");
+});
+
+test("mønstre kan overstyres fra env, og ugyldig regex stopper oppstarten", () => {
+  const custom = patternFromEnv("klar til bruk", DEFAULT_READY_PATTERN, "NVT_READY_PATTERN");
+  assert.equal(classifyPane("KLAR TIL BRUK", { ready: custom, onboarding: /aldri/ }), "ready");
+  assert.equal(patternFromEnv("  ", DEFAULT_READY_PATTERN, "x"), DEFAULT_READY_PATTERN);
+  assert.throws(() => patternFromEnv("(ubalansert", DEFAULT_READY_PATTERN, "NVT_READY_PATTERN"), /NVT_READY_PATTERN/);
+});

--- a/apps/nvt-bridge/src/nvt/ready.test.ts
+++ b/apps/nvt-bridge/src/nvt/ready.test.ts
@@ -3,7 +3,9 @@ import { test } from "node:test";
 import { classifyPane, DEFAULT_READY_PATTERN, patternFromEnv } from "./ready.ts";
 
 test("velkomstskjerm og trust-dialog klassifiseres som onboarding", () => {
-  assert.equal(classifyPane("╭─ Welcome to Claude Code ─╮"), "onboarding");
+  // Slik claude faktisk tegner dem: tekst inne i en ramme.
+  assert.equal(classifyPane("│ ✻ Welcome to Claude Code!"), "onboarding");
+  assert.equal(classifyPane("╭─────────╮\n│ Do you trust the files in this folder?"), "onboarding");
   assert.equal(classifyPane("Do you trust the files in this folder?"), "onboarding");
   assert.equal(classifyPane("  Press Enter to continue…"), "onboarding");
 });
@@ -20,6 +22,25 @@ test("en onboarding-dialog oppå en ellers klar sesjon er IKKE klar", () => {
     "onboarding",
     "dialogen fanger tastetrykket — å gjette «ready» her er nettopp M0-feilen",
   );
+});
+
+test("oppgavetekst i transkriptet utløser IKKE onboarding-tilstand", () => {
+  // Panelet inneholder claudes transkript, altså den delegerte prompten —
+  // upålitelig input. Uten linjeanker kunne avsender fått broen til å tro at en
+  // dialog sto der, og dermed blokkert topicet (og fått Enter sendt inn i en
+  // levende sesjon).
+  const pane = [
+    "> Fiks dette: dialogen «Do you trust the files in this folder?» henger",
+    "● Ser på saken …",
+    "│ > ",
+    "  ? for shortcuts",
+  ].join("\n");
+  assert.equal(classifyPane(pane), "ready");
+});
+
+test("bare de siste linjene av panelet vurderes", () => {
+  const pane = ["Welcome to Claude Code", ...Array(40).fill("● jobber …")].join("\n");
+  assert.equal(classifyPane(pane), "unknown", "gammelt transkript skal ikke matche");
 });
 
 test("et panel som jobber er verken onboarding eller ready", () => {

--- a/apps/nvt-bridge/src/nvt/ready.ts
+++ b/apps/nvt-bridge/src/nvt/ready.ts
@@ -24,9 +24,25 @@ export type PaneState =
 /**
  * Skjermene som spiser prompten. `Press Enter to continue` og trust-dialogen er
  * de som traff i M0; resten er de andre førstegangsskjermene claude kan vise.
+ *
+ * Mønstrene er **linjeankrede** med vilje. Panelet inneholder også claudes
+ * transkript, altså den delegerte prompten — upålitelig input. Uten anker
+ * kunne en oppgavetekst som inneholdt «Do you trust the files» fått broen til
+ * å tro at en dialog sto der, og dermed blokkert topicet.
+ *
+ * Ankeret godtar rammetegn og punktmarkører foran teksten (dialogene tegnes i
+ * en boks: `│ ✻ Welcome to Claude Code!`), men **ikke** vanlig tekst eller
+ * `>` — og et ekko av oppgaveteksten står alltid bak en `>`-prompt eller inne i
+ * en setning. Det er skillet som gjør mønsteret trygt mot upålitelig input.
  */
 export const DEFAULT_ONBOARDING_PATTERN =
-  /(Welcome to Claude Code|Do you trust the files|trust the files in this folder|Press Enter to continue|Choose the text style|Yes, proceed)/i;
+  /^[\s│┃╭╮╰╯─━┌┐└┘✻✳✽*•]*(Welcome to Claude Code|Do you trust the files|Press Enter to continue|Choose the text style|Security notes)/im;
+
+/**
+ * Hvor mange linjer fra bunnen av panelet vi ser på. Dialogene tegnes på den
+ * synlige skjermen; eldre transkript er bare støy som kan matche tilfeldig.
+ */
+export const PANE_TAIL_LINES = 24;
 
 /**
  * Klar-prompten. `? for shortcuts` er footeren claude viser når input-boksen
@@ -50,14 +66,24 @@ export const DEFAULT_PANE_PATTERNS: PanePatterns = {
  * som ellers viser footeren, og da er det dialogen som får tastetrykket. Å
  * gjette «ready» der ville vært å injisere inn i dialogen — nøyaktig feilen vi
  * prøver å unngå.
+ *
+ * Klassifiseringen brukes bare på en **fersk** sesjon (se `waitUntilReady`).
+ * Da er transkriptet tomt eller kort, og risikoen for at oppgavetekst matcher
+ * er tilsvarende liten.
  */
 export function classifyPane(
   paneText: string,
   patterns: PanePatterns = DEFAULT_PANE_PATTERNS,
 ): PaneState {
-  if (patterns.onboarding.test(paneText)) return "onboarding";
-  if (patterns.ready.test(paneText)) return "ready";
+  const tail = lastLines(paneText, PANE_TAIL_LINES);
+  if (patterns.onboarding.test(tail)) return "onboarding";
+  if (patterns.ready.test(tail)) return "ready";
   return "unknown";
+}
+
+function lastLines(text: string, count: number): string {
+  const lines = text.split("\n");
+  return lines.length <= count ? text : lines.slice(-count).join("\n");
 }
 
 /**

--- a/apps/nvt-bridge/src/nvt/ready.ts
+++ b/apps/nvt-bridge/src/nvt/ready.ts
@@ -1,0 +1,75 @@
+/**
+ * Klar-tilstand for CLI-sesjonen i instansen (M0-funn 5).
+ *
+ * `agentd` venter selv på at `session-launched`-markøren og tmux-sesjonen
+ * finnes før den køer en prompt — men det sier bare at *tmux* lever. Claude kan
+ * fortsatt stå på velkomstskjermen eller i trust-dialogen, og da går prompten
+ * inn i dialogen i stedet for i sesjonen. Oppgaven forsvinner uten spor: ingen
+ * feil, ingen `signal done`, bare en time med venting.
+ *
+ * Derfor leser broen tmux-panelet og klassifiserer det. Det er
+ * mønstergjenkjenning mot et TUI, altså heuristikk — så mønstrene kan
+ * overstyres med env (`NVT_READY_PATTERN`, `NVT_ONBOARDING_PATTERN`) uten
+ * kodeendring når claude bytter ordlyd.
+ */
+
+export type PaneState =
+  /** En onboarding-dialog står i veien. Et Enter tar oss videre. */
+  | "onboarding"
+  /** Sesjonen viser klar-prompt: trygt å injisere. */
+  | "ready"
+  /** Verken/eller — sesjonen kan være midt i arbeid, eller ikke tegnet ennå. */
+  | "unknown";
+
+/**
+ * Skjermene som spiser prompten. `Press Enter to continue` og trust-dialogen er
+ * de som traff i M0; resten er de andre førstegangsskjermene claude kan vise.
+ */
+export const DEFAULT_ONBOARDING_PATTERN =
+  /(Welcome to Claude Code|Do you trust the files|trust the files in this folder|Press Enter to continue|Choose the text style|Yes, proceed)/i;
+
+/**
+ * Klar-prompten. `? for shortcuts` er footeren claude viser når input-boksen
+ * tar imot tekst; `Bypassing Permissions` er indikatoren i
+ * `--dangerously-skip-permissions`-modus.
+ */
+export const DEFAULT_READY_PATTERN = /(\? for shortcuts|Bypassing Permissions|│\s*>)/;
+
+export interface PanePatterns {
+  ready: RegExp;
+  onboarding: RegExp;
+}
+
+export const DEFAULT_PANE_PATTERNS: PanePatterns = {
+  ready: DEFAULT_READY_PATTERN,
+  onboarding: DEFAULT_ONBOARDING_PATTERN,
+};
+
+/**
+ * Onboarding vinner over klar-prompt: en dialog kan være tegnet oppå en sesjon
+ * som ellers viser footeren, og da er det dialogen som får tastetrykket. Å
+ * gjette «ready» der ville vært å injisere inn i dialogen — nøyaktig feilen vi
+ * prøver å unngå.
+ */
+export function classifyPane(
+  paneText: string,
+  patterns: PanePatterns = DEFAULT_PANE_PATTERNS,
+): PaneState {
+  if (patterns.onboarding.test(paneText)) return "onboarding";
+  if (patterns.ready.test(paneText)) return "ready";
+  return "unknown";
+}
+
+/**
+ * Bygger et mønster fra env. Ugyldig regex skal stoppe oppstarten, ikke gi en
+ * sesjon som aldri blir «klar».
+ */
+export function patternFromEnv(raw: string | undefined, fallback: RegExp, name: string): RegExp {
+  const value = (raw ?? "").trim();
+  if (value === "") return fallback;
+  try {
+    return new RegExp(value, "i");
+  } catch (err) {
+    throw new Error(`${name}: ugyldig regulært uttrykk (${err instanceof Error ? err.message : err})`);
+  }
+}

--- a/doc/log.md
+++ b/doc/log.md
@@ -6,6 +6,24 @@ description: Append-only kronologi over endringer i repoets kunnskapsbase. Nyest
 
 # Logg
 
+- **2026-07-31** — nvt M1-adapteren (issue #97) kalibrert mot M0-funnene.
+  `agent-init` kjøres nå som `scripts/agent-init.sh --user non-root` (make-målet
+  forwarder ikke `--user`), fordi claude nekter bypass-flagget som root.
+  Ny **klar-sjekk** før hver prompt: `session-launched`-markøren må finnes,
+  tmux-sesjonen svare, og panelet ikke vise en onboarding-dialog — ellers
+  spises prompten uten spor. Enter sendes bare når en dialog faktisk står der,
+  aldri i blinde, og timeout gir en ærlig `status:"error"`-linje uten at
+  prompten er sendt. Broen validerer at `NVT_ROOT` og triggers-katalogen kan
+  traverseres av uid 1000 (fail-fast på Linux, advarsel på macOS), og genererer
+  instansens `agent.yaml` med `identity.mode: explicit` — `mode: provider`
+  virker ikke for broker-token, og en eksisterende config med den stopper
+  oppstarten i stedet for å gi en agent uten commit-identitet. Bot-navnet
+  kommer fra env, ikke fra repoet. Volum-hygienen ved bytte root→non-root
+  (`agent-<navn>_agent-home`/`_docker-data` må slettes) er dokumentert i
+  [`apps/nvt-bridge/README.md`](../apps/nvt-bridge/README.md). 119 tester
+  (fra 77); fake-driveren håndhever nå klar-sjekk-før-prompt som kontrakt.
+  Fortsatt ikke kjørt ende-til-ende mot en ekte instans — M1 lukkes først da.
+
 - **2026-07-30** — nvt M0 (issue #96) gjennomført: sandkasse-bevis på WSL2
   med hele kjeden prompt → levende claude-sesjon (Sonnet via llm-gatewayen)
   → branch/commit/push/PR av bot-identiteten med broker-utstedt token;


### PR DESCRIPTION
Kalibrerer den ekte nvt-adapteren i `apps/nvt-bridge/` mot M0-funnene i
`doc/plans/nvt-agent-integrasjon.md` § «M0-funn». Adapteren ble bevisst levert
som ukalibrert skall i #110.

Refs #97

## Hva som er endret

**1. `agent-init` med `--user non-root`** — claude nekter
`--dangerously-skip-permissions` som root, og tmux-sesjonen dør innen 5 s.
Kjøres nå som `bash scripts/agent-init.sh --name … --user non-root` fra
`NVT_ROOT`, ikke via `make`: make-målet i nvt kaller scriptet med
`--name/--type/--autonomy` og forwarder ikke `--user`. `agent-up`/`agent-down`
går fortsatt gjennom make.

**2. Klar-sjekk før prompt** (`waitUntilReady`, ny metode i driver-interfacet).
Onboardingen er en sesjonsstart-tilstand, så gaten har to nivåer:

| Tilstand | Krav |
| --- | --- |
| Fersk sesjon | `session-launched`-markøren finnes, tmux svarer, og panelet viser klar-prompt. Onboarding-dialog ⇒ ett Enter per runde (maks 3, konfigurerbart). |
| Bekreftet sesjon | Markør + levende tmux. Panelet leses ikke. |

Timeout kaster ⇒ prompten sendes ikke, og eventet får en `status:"error"`-linje
med peker til code-server. Feilmeldingen gjengir **aldri** panelinnholdet: den
går videre til Slack, og en tmux-skjerm kan inneholde hva som helst.

**3. Sti-validering ved oppstart** — `NVT_ROOT` og triggers-katalogen må kunne
traverseres av uid 1000 (triggers også skrives, siden agenten appender
resultatlinja selv). Symlenker løses først. Kaster bare når broen faktisk ser
hosten (Linux, ikke i container); ellers advarsel, fordi mount-point-foreldre i
broens namespace ikke er hostens kataloger.

**4. Volum-hygiene dokumentert** — bytte root→non-root på en eksisterende
instans krever at `agent-<navn>_agent-home` og `_docker-data` slettes. Står i
README med kommandoen og hva som går tapt.

**5. `agent.yaml` genereres med `identity.mode: explicit`** — broker-token kan
ikke rapportere commit-identitet, så `mode: provider` (nvt-malens eksempel) gir
en agent som feiler på `git commit` etter at jobben er gjort. Navn og e-post
kommer fra env (`NVT_GIT_IDENTITY_NAME`/`_EMAIL`) — bot-navnet holdes utenfor
repoet. En eksisterende config røres aldri, men verifiseres: `mode: provider`
stopper oppstarten i stedet for å bli stille rettet.

**6. Tester:** 77 → 129. `FakeNvtDriver` håndhever nå klar-sjekk-før-prompt som
kontraktbrudd, så en fremtidig endring som dropper sjekken feiler testene.

## Designvalg som ikke var avgjort i bestillingen

- **Klar-sjekk framfor «send to Enter i blinde».** Et blindt Enter inn i en
  sesjon som venter på svar ville sendt av halvskrevet input. Enter sendes bare
  når en dialog faktisk er tegnet i en sesjon som ikke har vært i bruk.
- **Panelet leses bare på en fersk sesjon.** Ellers inneholder det transkriptet,
  altså den delegerte oppgaveteksten (upålitelig input). Lot vi den styre gaten,
  kunne en avsender blokkert et topic ved å skrive dialogteksten i oppgaven.
  Mønstrene er i tillegg linjeankret. Dette var et reelt funn i reviewen, ikke
  teori.
- **Broen skriver `agent.yaml`, nvt-malen brukes ikke.** `agent-init` skriver
  bare malen når fila mangler, og malen har `plugins: []`. Prisen er at nye
  seksjoner i nvt-malen ikke kommer automatisk inn i våre instanser.
- **Mønstre og timeout i env.** TUI-gjenkjenning er heuristikk; den skal kunne
  rettes uten kodeendring.
- **Ingen `mode: provider`-autofiks.** En håndredigert config rettes ikke
  stille; broen nekter og forklarer.

## Ikke verifisert

Ende-til-ende mot en ekte nvt-instans er **ikke** kjørt (ingen Docker i
kjøremiljøet mitt). Containernavnet `agent-<navn>-agent-1`, `subscribe`-formatet
og klar-mønstrene er fortsatt antakelser — de er listet i kommentaren øverst i
`src/nvt/docker.ts`. Det er E2E-steget som lukker M1, ikke denne PR-en.

`integrations/src/` er urørt. `docker-compose.yml` og `Dockerfile` er ikke rørt,
så diffen treffer ingen CODEOWNERS-sti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)